### PR TITLE
Fixed incorrect submodule names during importing

### DIFF
--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -20,10 +20,10 @@ import os
 
 from shapelets.self_assembly import (
     convresponse,
-    readimage,
+    read_image,
     rdistance,
     get_wavelength,
-    process
+    process_output
 ) 
 
 ## Section 2: parameters
@@ -37,7 +37,7 @@ uy = [150, 180]
 
 # 3.1: image and output directory handling
 image_path = os.getcwd()+'/images/'
-image = readimage(image_name = image_name, image_path = image_path)
+image = read_image(image_name = image_name, image_path = image_path)
 save_path = os.getcwd()+'/output/'
 if not os.path.exists(save_path): os.mkdir("output")
 
@@ -54,4 +54,4 @@ except NameError:
     rd_field = rdistance(image = image, response = response, num_clusters = num_clusters, ux = 'default', uy = 'default')
 
 # processing and saving the results to the **output/** directory 
-process(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)
+process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)

--- a/examples/example_2/example_2.py
+++ b/examples/example_2/example_2.py
@@ -20,10 +20,10 @@ import os
 
 from shapelets.self_assembly import (
     convresponse,
-    readimage,
+    read_image,
     defectid,
     get_wavelength,
-    process
+    process_output
 ) 
 
 ## Section 2: parameters
@@ -35,7 +35,7 @@ num_clusters = 10
 
 # 3.1: image and output directory handling
 image_path = os.getcwd()+'/images/'
-image = readimage(image_name = image_name, image_path = image_path)
+image = read_image(image_name = image_name, image_path = image_path)
 save_path = os.getcwd()+'/output/'
 if not os.path.exists(save_path): os.mkdir("output")
 
@@ -52,4 +52,4 @@ except NameError:
     centroids, clusterMembers, defects = defectid(response = response, l = char_wavelength, pattern_order = pattern_order, num_clusters = 'default')
 
 # processing and saving the results to the **output/** directory 
-process(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)
+process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)

--- a/examples/example_3/example_3.py
+++ b/examples/example_3/example_3.py
@@ -20,10 +20,10 @@ import os
 
 from shapelets.self_assembly import (
     convresponse,
-    readimage,
+    read_image,
     orientation,
     get_wavelength,
-    process
+    process_output
 ) 
 
 ## Section 2: parameters
@@ -34,7 +34,7 @@ pattern_order = "square"
 
 # 3.1: image and output directory handling
 image_path = os.getcwd()+'/images/'
-image = readimage(image_name = image_name, image_path = image_path)
+image = read_image(image_name = image_name, image_path = image_path)
 save_path = os.getcwd()+'/output/'
 if not os.path.exists(save_path): os.mkdir("output")
 
@@ -48,4 +48,4 @@ response, orients = convresponse(image = image, l = char_wavelength, shapelet_or
 mask, dilate, blended, maxval = orientation(pattern_order = pattern_order, l = char_wavelength, response = response, orients = orients)
 
 # processing and saving the results to the **output/** directory 
-process(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)
+process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)


### PR DESCRIPTION
Noticed bug in the example_1.py, example_2.py, and example_3.py files where old submodule names were used during import, rendering the code useless... updated submodule names to reflect current codebase.