### PR TITLE
Converted function docstrings from .rst to .md, removed unnecessary carriage returns

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pip install -e .
       # ADJUST THIS: build your documentation into docs/.
       # We use a custom build script for pdoc itself, ideally you just run `pdoc -o docs/ ...` here.
-      - run: pdoc -o docs/ shapelets
+      - run: pdoc --math -o docs/ shapelets
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/shapelets/astronomy/galaxy.py
+++ b/shapelets/astronomy/galaxy.py
@@ -39,11 +39,11 @@ class Stamp:
     Parameters
     ----------
     * x1: np.ndarray (dtype=int)
-        * coordinate representing the corner of postage stamp closest to origin (inclusive)
+        * Coordinate representing the corner of postage stamp closest to origin (inclusive)
     * x2: np.ndarray (dtype=int)
-        * coordinate representing the corner of postage stamp farthest to origin (inclusive)
+        * Coordinate representing the corner of postage stamp furthest from origin (inclusive)
     * xc: np.ndarray (dtype=float)
-        * representing middle of celestial object in postage stamp
+        * Representing middle of celestial object in postage stamp
     * beta: float
         * The characteristic shapelet scale that the celestial object will be decomposed at
 
@@ -110,17 +110,20 @@ def get_postage_stamps(data: np.ndarray, output_path: str=None, SHOW_STAMPS: boo
     Parameters
     ----------
     * data: np.ndarray
-        * $n\times m$ ndarray of astronomical image data
+        * $n\times m$ array of astronomical image data
+    * output_path: str, optional
+        * Folder to store output images. If set to None (default), no images are saved
     * SHOW_STAMPS: bool, optional
         * If set to True (default) displays astronomical image data with stamps identified
         
     Returns
     -------
-    * galaxy_stamp_list: [Stamp]
-        * list of stamps for the galaxies found in the astronomical image data
-    * star_stamp_list: [Stamp]
-        * list of stamps for the stars found in the astronomical image data
-    * data: 
+    * galaxy_stamp_list: list[Stamp]
+        * List of stamps for the galaxies found in the astronomical image data
+    * star_stamp_list: list[Stamp]
+        * List of stamps for the stars found in the astronomical image data
+    * data: np.ndarray
+        * $n\times m$ array of astronomical image data, minus the background determined by the ``sep`` python package 
 
     """
     if output_path == None:
@@ -208,21 +211,21 @@ def get_postage_stamps(data: np.ndarray, output_path: str=None, SHOW_STAMPS: boo
 
 def load_fits_data(filename: str) -> np.ndarray:
     r"""
-    Loads data as ndarray from provided .fits file.
+    Loads data as numpy.ndarray from provided .fits file.
 
     Parameters
     ----------
     * filename: str
-        * absolute or relative filepath to .fits file
+        * Absolute or relative filepath to .fits file
         
     Returns
     -------
     * data: np.ndarray
-        * returns nxm ndarray of the astronomical image data
+        * $n \times m$ array of astronomical image data
     
     Notes
     -----
-    Flexible Image Transport System (or FITS) files were designed to standarize the exchange of astronomical image data between observatories [1]_. FITS provide a method to transport arrays and tables of data alongside its related metadata. 
+    Flexible Image Transport System (or FITS) files were designed to standarize the exchange of astronomical image data between observatories[1]_. FITS provides a method to transport arrays and tables of data alongside its related metadata. 
     
     References
     ----------
@@ -241,15 +244,15 @@ def create_plots(data: np.ndarray, reconstructed: np.ndarray, reconstructed_comp
     Parameters
     ----------
     * data: np.ndarray
-        * original astronomical data
+        * Original astronomical data
     * reconstructed: np.ndarray
-        * reconstruction of astronomical data using calculated shapelet coefficients
+        * Reconstruction of astronomical data using calculated shapelet coefficients
     * reconstructed_compressed: np.ndarray
-        * reconstruction of astronomical data using truncated list of shapelet coefficients
+        * Reconstruction of astronomical data using truncated list of shapelet coefficients
     * compression_factor: int
-        * length of truncated list of shapelet coefficients used to reconstruct astronomical data
+        * Length of truncated list of shapelet coefficients used to reconstruct astronomical data
     * output_path: str, optional
-        * file_path to save images to. If set to None (default), then fig is not saved
+        * File_path to save images to. If set to None (default), then fig is not saved
         
     """
     fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)

--- a/shapelets/astronomy/galaxy.py
+++ b/shapelets/astronomy/galaxy.py
@@ -38,14 +38,14 @@ class Stamp:
 
     Parameters
     ----------
-    x1 : np.ndarray (dtype=int)
-        coordinate representing the corner of postage stamp closest to origin (inclusive)
-    x2 : np.ndarray (dtype=int)
-        coordinate representing the corner of postage stamp farthest to origin (inclusive)
-    xc : np.ndarray (dtype=float)
-        representing middle of celestial object in postage stamp
-    beta : float
-        The characteristic shapelet scale that the celestial object will be decomposed at
+    * x1: np.ndarray (dtype=int)
+        * coordinate representing the corner of postage stamp closest to origin (inclusive)
+    * x2: np.ndarray (dtype=int)
+        * coordinate representing the corner of postage stamp farthest to origin (inclusive)
+    * xc: np.ndarray (dtype=float)
+        * representing middle of celestial object in postage stamp
+    * beta: float
+        * The characteristic shapelet scale that the celestial object will be decomposed at
 
     """
     x1: np.ndarray
@@ -59,21 +59,22 @@ def decompose_galaxies(galaxy_stamps: list[Stamp], star_stamps: list[Stamp], dat
 
     Parameters
     ----------
-    galaxy_stamp_list : [Stamp]
-        list of stamps for the galaxies in the astronomical image data
-    star_stamp_list : [Stamp]
-        list of stamps for the stars in the astronomical image data
-    data : list[Stamp]
-        original astronomical data
-    n_max: int
-        maximum order of shapelets
-    compression_factor : int
-        length of truncated list of shapelet coefficients used to reconstruct astronomical data
-    output_path : folder to store output images. if set to None no images are saved
+    * galaxy_stamps: list[Stamp]
+        * List of stamps for the galaxies in the astronomical image data
+    * star_stamps: list[Stamp]
+        * List of stamps for the stars in the astronomical image data
+    * data: np.ndarray
+        * Original astronomical data
+    * n_max: int
+        * Maximum order of shapelets
+    * n_compress: int
+        * Length of truncated list of shapelet coefficients used to reconstruct astronomical data
+    * output_path: str, optional
+        * Folder to store output images. If set to None (default), no images are saved
         
     """
     if output_path == None:
-        print("No output path provided, galaxy decomposition comparisons will not be saved")
+        print("No output path provided, galaxy decomposition comparisons will not be saved.")
 
     # run shapelet deconvolution on each galaxy stamp
     for stamp in galaxy_stamps:
@@ -108,17 +109,18 @@ def get_postage_stamps(data: np.ndarray, output_path: str=None, SHOW_STAMPS: boo
 
     Parameters
     ----------
-    data : np.ndarray
-        nxm ndarray of astronomical image data
-    SHOW_STAMPS : bool
-        if set to True displays astronomical image data with stamps identified
+    * data: np.ndarray
+        * $n\times m$ ndarray of astronomical image data
+    * SHOW_STAMPS: bool, optional
+        * If set to True (default) displays astronomical image data with stamps identified
         
     Returns
     -------
-    galaxy_stamp_list : [Stamp]
-        list of stamps for the galaxies found in the astronomical image data
-    star_stamp_list : [Stamp]
-        list of stamps for the stars found in the astronomical image data
+    * galaxy_stamp_list: [Stamp]
+        * list of stamps for the galaxies found in the astronomical image data
+    * star_stamp_list: [Stamp]
+        * list of stamps for the stars found in the astronomical image data
+    * data: 
 
     """
     if output_path == None:
@@ -198,7 +200,10 @@ def get_postage_stamps(data: np.ndarray, output_path: str=None, SHOW_STAMPS: boo
 
     fig.text(0.5, 0.05, 'Close figure to Continue', horizontalalignment='center',
              verticalalignment='center', fontsize=8)
-    if SHOW_STAMPS: plt.show()
+    
+    if SHOW_STAMPS: 
+        plt.show()
+
     return galaxy_stamp_list, star_stamp_list, data
 
 def load_fits_data(filename: str) -> np.ndarray:
@@ -207,17 +212,17 @@ def load_fits_data(filename: str) -> np.ndarray:
 
     Parameters
     ----------
-    filename : str
-        absolute or relative filepath to .fits file
+    * filename: str
+        * absolute or relative filepath to .fits file
         
     Returns
     -------
-    data : np.ndarray
-        returns nxm ndarray of the astronomical image data
+    * data: np.ndarray
+        * returns nxm ndarray of the astronomical image data
     
     Notes
     -----
-    Flexible Image Transport System (or FITS) files were designed to standarize the exchange of astronomical image data between observatories[1]. FITS provide a method to transport arrays and tables of data alongside its related metadata. 
+    Flexible Image Transport System (or FITS) files were designed to standarize the exchange of astronomical image data between observatories [1]_. FITS provide a method to transport arrays and tables of data alongside its related metadata. 
     
     References
     ----------
@@ -231,20 +236,20 @@ def load_fits_data(filename: str) -> np.ndarray:
     
 def create_plots(data: np.ndarray, reconstructed: np.ndarray, reconstructed_compressed: np.ndarray, compression_factor: int, output_path: str=None) -> None:
     r"""
-    Displays original data and image reconstructions, alongside an error.
+    Displays original data and image reconstructions, alongside the error from projection onto shapelet basis.
 
     Parameters
     ----------
-    data : np.ndarray
-        original astronomical data
-    reconstructed : np.ndarray
-        reconstruction of astronomical data using calculated shapelet coefficients
-    reconstructed_compressed : np.ndarray
-        reconstruction of astronomical data using truncated list of shapelet coefficients
-    compression_factor : int
-        length of truncated list of shapelet coefficients used to reconstruct astronomical data
-    output_path : string
-        file_path to save images to. if set to None fig is not saved
+    * data: np.ndarray
+        * original astronomical data
+    * reconstructed: np.ndarray
+        * reconstruction of astronomical data using calculated shapelet coefficients
+    * reconstructed_compressed: np.ndarray
+        * reconstruction of astronomical data using truncated list of shapelet coefficients
+    * compression_factor: int
+        * length of truncated list of shapelet coefficients used to reconstruct astronomical data
+    * output_path: str, optional
+        * file_path to save images to. If set to None (default), then fig is not saved
         
     """
     fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)

--- a/shapelets/astronomy/galaxy.py
+++ b/shapelets/astronomy/galaxy.py
@@ -15,15 +15,13 @@
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
 
-import numpy as np
-
 from dataclasses import dataclass
-from astropy.io import fits
-import sep
 
+from astropy.io import fits
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse, Patch
-
+import numpy as np
+import sep
 
 from .misc import *
 

--- a/shapelets/astronomy/misc.py
+++ b/shapelets/astronomy/misc.py
@@ -30,21 +30,21 @@ def decompose_analytic(image: np.ndarray, n_max: int, beta: float, centroid: np.
 
     Parameters
     ----------
-    image: np.ndarray
-        data to be decomposed into shapelet functions
-    n_max: int
-        maximum order of shapelets
-    beta: float
-        characteristic shapelet scale that the object was decomposed at
-    centroid: np.ndarray (dtype=float)
-        center of shapelet reconstruction (relative to image dimensions)
-    nspace: [(int, int)] (optional)
-        list of shapelet coefficients to be used in the reconstruction
+    * image: np.ndarray
+        * data to be decomposed into shapelet functions
+    * n_max: int
+        * maximum order of shapelets
+    * beta: float
+        * characteristic shapelet scale that the object was decomposed at
+    * centroid: np.ndarray (dtype=float)
+        * center of shapelet reconstruction (relative to image dimensions)
+    * nspace: [(int, int)], optional
+        * list of shapelet coefficients to be used in the reconstruction. Default is None
 
     Returns
     -------
-    coefficients : np.ndarray (dtype=float)
-        matrix of shapelet coefficients representing the decomposition of the image
+    * coefficients: np.ndarray (dtype=float)
+        * matrix of shapelet coefficients representing the decomposition of the image
     
     Notes
     -----
@@ -84,21 +84,21 @@ def decompose_kernel(image: np.ndarray, n_max: int, beta: float, centroid: np.nd
 
     Parameters
     ----------
-    image: np.ndarray
-        data to be decomposed into shapelet functions
-    n_max: int
-        maximum order of shapelets
-    beta: float
-        characteristic shapelet scale that the object was decomposed at
-    centroid: np.ndarray (dtype=float)
-        center of shapelet reconstruction (relative to image dimensions)
-    nspace: [(int, int)] (optional)
-        list of shapelet coefficients to be used in the reconstruction
+    * image: np.ndarray
+        * data to be decomposed into shapelet functions
+    * n_max: int
+        * maximum order of shapelets
+    * beta: float
+        * characteristic shapelet scale that the object was decomposed at
+    * centroid: np.ndarray (dtype=float)
+        * center of shapelet reconstruction (relative to image dimensions)
+    * nspace: [(int, int)], optional
+       * list of shapelet coefficients to be used in the reconstruction. Default is None
 
     Returns
     -------
-    coefficients : np.ndarray (dtype=float)
-        matrix of shapelet coefficients representing the decomposition of the image
+    * coefficients : np.ndarray (dtype=float)
+        * matrix of shapelet coefficients representing the decomposition of the image
 
     """
     coefficients = np.zeros([n_max+1]*2)
@@ -125,23 +125,23 @@ def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarr
 
     Parameters
     ----------
-    s_coeff: np.ndarray (dtype=float)
-        matrix of shapelet coefficients
-    n_max: int
+    * s_coeff: np.ndarray (dtype=float)
+        * matrix of shapelet coefficients
+    * n_max: int
         maximum order of shapelets
-    beta: float
-        characteristic shapelet scale that the object was decomposed at
-    centroid: np.ndarray (dtype=float)
-        center of shapelet reconstruction (relative to image dimensions)
-    dimensions: (int, int)
-        the resolution of the image
-    nspace: [(int, int)] (optional)
-        list of shapelet coefficients to be used in the reconstruction
+    * beta: float
+        * characteristic shapelet scale that the object was decomposed at
+    * centroid: np.ndarray (dtype=float)
+        * center of shapelet reconstruction (relative to image dimensions)
+    * dimensions: (int, int)
+        * the resolution of the image
+    * nspace: [(int, int)], optional
+        * list of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns
     -------
-    image : np.ndarray (dtype=float)
-        the reconstructed image
+    * image: np.ndarray (dtype=float)
+        * the reconstructed image
     
     """
     if nspace == None:
@@ -166,23 +166,23 @@ def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centr
 
     Parameters
     ----------
-    coeff : np.ndarray
-        data to be decomposed into shapelet functions
-    n_max : int
-        maximum order of shapelets
-    beta : float
-        characteristic shapelet scale that the object was decomposed at
-    centroid : np.ndarray (dtype=float)
-        center of shapelet reconstruction (relative to image dimensions)
-    nspace : [(int, int)] (optional)
-        list of shapelet coefficients to be used in the reconstruction
+    * coeff: np.ndarray
+        * data to be decomposed into shapelet functions
+    * n_max: int
+        * maximum order of shapelets
+    * beta: float
+        * characteristic shapelet scale that the object was decomposed at
+    * centroid: np.ndarray (dtype=float)
+        * center of shapelet reconstruction (relative to image dimensions)
+    * nspace: [(int, int)] (optional)
+        * list of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns
     -------
-    new_beta : float
-        updated shapelet scale for future decomposition
-    new_centroid : np.ndarray
-        updated image center for future decomposition
+    * new_beta: float
+        * updated shapelet scale for future decomposition
+    * new_centroid: np.ndarray
+        * updated image center for future decomposition
 
     References
     ----------
@@ -204,17 +204,17 @@ def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centr
 
 def get_nspace(n_max: int) -> np.ndarray:
     r"""
-    Returns a set of (n1, n2) combinations such that the sum of the elements of n is less than n_max (||n||_1 <= n_max).
+    Returns a set of (n1, n2) combinations such that the sum of the elements of n is less than n_max, i.e. $||n||_1 \leq n_max$.
 
     Parameters
     ----------
-    n_max : int
-        maximum order of shapelet
+    * n_max: int
+        * maximum order of shapelet
         
     Returns
     -------
-    nspace : np.ndarray (dtype=tuple)
-        list of valid (n1, n2) combinations such that n1 + n2 <= n_max
+    * nspace: np.ndarray (dtype=tuple)
+        * list of valid (n1, n2) combinations such that $n1 + n2 <= n_max$
 
     """
     nspace = np.ndarray(int(binom(n_max+2, 2)), dtype=tuple)
@@ -233,19 +233,19 @@ def get_compressed_nspace(s_coeff: np.ndarray, n_compress: int) -> np.ndarray:
 
     Parameters
     ----------
-    s_coeff : np.ndarray (float)
-        matrix of coefficient values
-    n_compress : int
-        number of shapelet coefficients to preserve
+    * s_coeff: np.ndarray (dtype=float)
+        * matrix of coefficient values
+    * n_compress: int
+        * number of shapelet coefficients to preserve
         
     Returns
     -------
-    nspace : np.ndarray (dtype=tuple)
-        list of tuples of largest valid (n1, n2) combinations
+    * nspace: np.ndarray (dtype=tuple)
+        * list of tuples of largest valid (n1, n2) combinations
 
     Notes
     -----
-    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients. Ignoring smaller coefficient functions helps to avoid overfitting to the image noise
+    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients. Ignoring smaller coefficient functions helps to avoid overfitting to the image noise.
 
     Examples
     -----

--- a/shapelets/astronomy/misc.py
+++ b/shapelets/astronomy/misc.py
@@ -15,8 +15,9 @@
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
 
-import numpy as np
 from math import comb as choose
+
+import numpy as np
 from scipy.special import binom, erf
 
 from ..functions import cartesian1D, cartesian2D
@@ -244,8 +245,7 @@ def get_compressed_nspace(s_coeff: np.ndarray, n_compress: int) -> np.ndarray:
 
     Notes
     -----
-    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients.
-    Ignoring smaller coefficient functions helps to avoid overfitting to the image noise
+    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients. Ignoring smaller coefficient functions helps to avoid overfitting to the image noise
 
     Examples
     -----

--- a/shapelets/astronomy/misc.py
+++ b/shapelets/astronomy/misc.py
@@ -119,7 +119,7 @@ def decompose_kernel(image: np.ndarray, n_max: int, beta: float, centroid: np.nd
     
     return coefficients
 
-def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarray, dimensions: tuple[int, int], nspace: list[tuple]=None) -> np.ndarray:
+def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarray, dimensions: tuple[int, int], nspace: list[tuple[int, int]]=None) -> np.ndarray:
     r"""
     Given a matrix of shapelet coefficients, constructs image.
 
@@ -135,7 +135,7 @@ def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarr
         * Center of shapelet reconstruction (relative to image dimensions)
     * dimensions: (int, int)
         * The resolution of the image
-    * nspace: list[tuple], optional
+    * nspace: list[tuple[int, int]], optional
         * List of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns
@@ -160,7 +160,7 @@ def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarr
     return image
 
 # calculate improved parameters to optimize shapelet coeffcients
-def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarray, nspace: list[tuple]=None) -> tuple[float, np.ndarray]:
+def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarray, nspace: list[tuple[int, int]]=None) -> tuple[float, np.ndarray]:
     r"""
     Calculates an object's characteristic scale and centroid using its calculated shapelet coefficients. These new parameters can be used to decompose the image again with lower error.
 
@@ -174,7 +174,7 @@ def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centr
         * Characteristic shapelet scale that the object was decomposed at
     * centroid: np.ndarray (dtype=float)
         * Center of shapelet reconstruction (relative to image dimensions)
-    * nspace: list[tuple], optional
+    * nspace: list[tuple[int, int]], optional
         * List of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns

--- a/shapelets/astronomy/misc.py
+++ b/shapelets/astronomy/misc.py
@@ -31,20 +31,20 @@ def decompose_analytic(image: np.ndarray, n_max: int, beta: float, centroid: np.
     Parameters
     ----------
     * image: np.ndarray
-        * data to be decomposed into shapelet functions
+        * Data to be decomposed into shapelet functions
     * n_max: int
-        * maximum order of shapelets
+        * Maximum order of shapelets
     * beta: float
-        * characteristic shapelet scale that the object was decomposed at
+        * Characteristic shapelet scale that the object was decomposed at
     * centroid: np.ndarray (dtype=float)
-        * center of shapelet reconstruction (relative to image dimensions)
-    * nspace: [(int, int)], optional
-        * list of shapelet coefficients to be used in the reconstruction. Default is None
+        * Center of shapelet reconstruction (relative to image dimensions)
+    * nspace: list[tuple[int, int]], optional
+        * List of shapelet coefficients to be used in the reconstruction. Default is None
 
     Returns
     -------
     * coefficients: np.ndarray (dtype=float)
-        * matrix of shapelet coefficients representing the decomposition of the image
+        * Matrix of shapelet coefficients representing the decomposition of the image
     
     Notes
     -----
@@ -85,20 +85,20 @@ def decompose_kernel(image: np.ndarray, n_max: int, beta: float, centroid: np.nd
     Parameters
     ----------
     * image: np.ndarray
-        * data to be decomposed into shapelet functions
+        * Data to be decomposed into shapelet functions
     * n_max: int
-        * maximum order of shapelets
+        * Maximum order of shapelets
     * beta: float
-        * characteristic shapelet scale that the object was decomposed at
+        * Characteristic shapelet scale that the object was decomposed at
     * centroid: np.ndarray (dtype=float)
-        * center of shapelet reconstruction (relative to image dimensions)
-    * nspace: [(int, int)], optional
-       * list of shapelet coefficients to be used in the reconstruction. Default is None
+        * Center of shapelet reconstruction (relative to image dimensions)
+    * nspace: list[tuple[int, int]], optional
+        * List of shapelet coefficients to be used in the reconstruction. Default is None
 
     Returns
     -------
     * coefficients : np.ndarray (dtype=float)
-        * matrix of shapelet coefficients representing the decomposition of the image
+        * Matrix of shapelet coefficients representing the decomposition of the image
 
     """
     coefficients = np.zeros([n_max+1]*2)
@@ -126,22 +126,22 @@ def reconstruct(s_coeff: np.ndarray, n_max: int, beta: float, centroid: np.ndarr
     Parameters
     ----------
     * s_coeff: np.ndarray (dtype=float)
-        * matrix of shapelet coefficients
+        * Matrix of shapelet coefficients
     * n_max: int
-        maximum order of shapelets
+        * Maximum order of shapelets
     * beta: float
-        * characteristic shapelet scale that the object was decomposed at
+        * Characteristic shapelet scale that the object was decomposed at
     * centroid: np.ndarray (dtype=float)
-        * center of shapelet reconstruction (relative to image dimensions)
+        * Center of shapelet reconstruction (relative to image dimensions)
     * dimensions: (int, int)
-        * the resolution of the image
-    * nspace: [(int, int)], optional
-        * list of shapelet coefficients to be used in the reconstruction. Default is None
+        * The resolution of the image
+    * nspace: list[tuple], optional
+        * List of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns
     -------
     * image: np.ndarray (dtype=float)
-        * the reconstructed image
+        * The reconstructed image
     
     """
     if nspace == None:
@@ -167,22 +167,22 @@ def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centr
     Parameters
     ----------
     * coeff: np.ndarray
-        * data to be decomposed into shapelet functions
+        * Data to be decomposed into shapelet functions
     * n_max: int
-        * maximum order of shapelets
+        * Maximum order of shapelets
     * beta: float
-        * characteristic shapelet scale that the object was decomposed at
+        * Characteristic shapelet scale that the object was decomposed at
     * centroid: np.ndarray (dtype=float)
-        * center of shapelet reconstruction (relative to image dimensions)
-    * nspace: [(int, int)] (optional)
-        * list of shapelet coefficients to be used in the reconstruction. Default is None
+        * Center of shapelet reconstruction (relative to image dimensions)
+    * nspace: list[tuple], optional
+        * List of shapelet coefficients to be used in the reconstruction. Default is None
     
     Returns
     -------
     * new_beta: float
-        * updated shapelet scale for future decomposition
+        * Updated shapelet scale for future decomposition
     * new_centroid: np.ndarray
-        * updated image center for future decomposition
+        * Updated image center for future decomposition
 
     References
     ----------
@@ -204,17 +204,17 @@ def update_shapelet_parameters(coeff: np.ndarray, n_max: int, beta: float, centr
 
 def get_nspace(n_max: int) -> np.ndarray:
     r"""
-    Returns a set of (n1, n2) combinations such that the sum of the elements of n is less than n_max, i.e. $||n||_1 \leq n_max$.
+    Returns a set of (n1, n2) combinations such that the sum of the elements of n is less than n_max, i.e. $||n||_1 \leq n_{max}$.
 
     Parameters
     ----------
     * n_max: int
-        * maximum order of shapelet
+        * Maximum order of shapelet
         
     Returns
     -------
     * nspace: np.ndarray (dtype=tuple)
-        * list of valid (n1, n2) combinations such that $n1 + n2 <= n_max$
+        * List of valid (n1, n2) combinations such that $n1 + n2 <= n_{max}$
 
     """
     nspace = np.ndarray(int(binom(n_max+2, 2)), dtype=tuple)
@@ -229,23 +229,23 @@ def get_nspace(n_max: int) -> np.ndarray:
 
 def get_compressed_nspace(s_coeff: np.ndarray, n_compress: int) -> np.ndarray:
     r"""
-    Trims shapelet coefficient to include only the n_compress largest coefficients.
+    Trims shapelet coefficient to include only the $n_{compress}$ largest coefficients.
 
     Parameters
     ----------
     * s_coeff: np.ndarray (dtype=float)
-        * matrix of coefficient values
+        * Matrix of coefficient values
     * n_compress: int
-        * number of shapelet coefficients to preserve
+        * Number of shapelet coefficients to preserve
         
     Returns
     -------
     * nspace: np.ndarray (dtype=tuple)
-        * list of tuples of largest valid (n1, n2) combinations
+        * List of tuples of largest valid (n1, n2) combinations
 
     Notes
     -----
-    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients. Ignoring smaller coefficient functions helps to avoid overfitting to the image noise.
+    Often an image can be accurately reconstructed using only several of the shapelet functions with the largest coefficients. Ignoring smaller coefficients helps to avoid overfitting to the image noise.
 
     Examples
     -----

--- a/shapelets/entry_points.py
+++ b/shapelets/entry_points.py
@@ -24,10 +24,7 @@ from .run import *
 
 def run_shapelets():
     r""" 
-
-    Main function that runs shapelets.
-    This is only invoked via the entry point "shapelets CONFIG" where
-        CONFIG is the name of the configuration plaintext file.      
+    Main function that runs shapelets. This is only invoked via the entry point "shapelets CONFIG" where CONFIG is the name of the configuration plaintext file.      
 
     """
     # Arguments for command line use
@@ -44,18 +41,14 @@ def run_shapelets():
 
 def run_tests():
     r"""
-    
-    Main function that runs all the unit tests from shapelets/tests/ via unittest from Python STL.
-    This is only invoked via the entry point "shapelets-test" from the top-most shapelets directory.
+    Main function that runs all the unit tests from shapelets/tests/ via unittest from Python STL. This is only invoked via the entry point "shapelets-test" from the top-most shapelets directory.
     
     """
-
     @contextlib.contextmanager
     def tempWorkingDir(path):
         r"""
         
-        Temporarily create a working directory to execute CLI commands without actually
-        changing the root of the global directory.
+        Temporarily create a working directory to execute CLI commands without actually changing the root of the global directory.
 
         From stackoverflow:
         https://stackoverflow.com/questions/75048986/way-to-temporarily-change-the-directory-in-python-to-execute-code-without-affect

--- a/shapelets/entry_points.py
+++ b/shapelets/entry_points.py
@@ -47,7 +47,6 @@ def run_tests():
     @contextlib.contextmanager
     def tempWorkingDir(path):
         r"""
-        
         Temporarily create a working directory to execute CLI commands without actually changing the root of the global directory.
 
         From stackoverflow:

--- a/shapelets/functions.py
+++ b/shapelets/functions.py
@@ -29,29 +29,29 @@ __all__ = [
     'exponential2D'
 ]
 
-def cartesian1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
+def cartesian1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
-    1D cartesian shapelet function defined as [1]_,
+    1D cartesian shapelet function defined as[1]_,
 
     $$ S_{n}(x; \beta) = \beta^{-\frac{1}{2}}  \phi_{n}(\frac{x}{\beta}) $$
 
     with $$ \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2}) $$
 
-    where $\phi_n$ is the dimensionless [shapelet] basis function, $\beta$ is the characteristic shapelet scale, $H_n$ is a hermite polynomial of order n, and $n$ is the shapelet order.
+    where $\phi_n$ is the dimensionless basis function, $\beta$ is the shapelet length scale, $H_n$ is a hermite polynomial of order $n$, and $n$ is the shapelet order parameter.
 
     Parameters
     ----------
     * n: int
-        * Shapelet order. Acceptable values $n \geq 0$.
-    * x1: float or np.ndarray
-        * The input to the shapelet function.
+        * Shapelet order. Acceptable values are $n \geq 0$
+    * x1: Union[float,np.ndarray]
+        * The input to the shapelet function
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1): float or np.ndarray
-        * Shapelet function evaluated at S(x1).
+    * Sc(x1): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1)
 
     References
     ----------
@@ -72,33 +72,33 @@ def cartesian1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
 
     return Sc(x1)
 
-def cartesian2D(n1: int, n2: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
+def cartesian2D(n1: int, n2: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
-    2D cartesian shapelet function defined as [1]_,
+    2D cartesian shapelet function defined as[1]_,
 
     $$ S_{n_1,n_2}(x_1, x_2; \beta) = \beta^{-1} \phi_{n_1}(\frac{x_1}{\beta}) \phi_{n_2}(\frac{x_2}{\beta}) $$
 
     with $$ \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2}) $$
 
-    where $\phi_n$ is the dimensionless [shapelet] basis function, $\beta$ is the characteristic shapelet scale, $H_n$ is a hermite polynomial of order n, and $n_1$ and $n_2$ are the shapelet orders.
+    where $\phi_n$ is the dimensionless basis function, $\beta$ is the shapelet length scale, $H_n$ is a hermite polynomial of order $n$, and $n_1$ and $n_2$ are the shapelet orders.
 
     Parameters
     ----------
     * n1: int
-        * Shapelet order in x direction. Acceptable values $n1 \geq 0$.
+        * Shapelet order in x direction. Acceptable values are $n1 \geq 0$
     * n2: int
-        * Shapelet order in y direction. Acceptable values $n2 \geq 0$.
-    * x1: float or np.ndarray
-        * First input to shapelet function.
-    * x2: float or np.ndarray
-        * Second input to shapelet function.
+        * Shapelet order in y direction. Acceptable values are $n2 \geq 0$
+    * x1: Union[float,np.ndarray]
+        * First input to shapelet function
+    * x2: Union[float,np.ndarray]
+        * Second input to shapelet function
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1, x2): float or np.ndarray
-        * Shapelet function evaluated at (x1, x2).
+    * Sc(x1, x2): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1, x2)
 
     References
     ----------
@@ -122,35 +122,35 @@ def cartesian2D(n1: int, n2: int, x1: Union[float,np.ndarray], x2: Union[float,n
 
     return Sc(x1, x2)
 
-def polar2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
+def polar2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
-    2D polar shapelet function defined as [1]_,
+    2D polar shapelet function defined as[1]_,
 
     $$ S_{n, m}(r, \theta; \beta) = \alpha_1 \alpha_2 r^{|m|} L_{(n-|m|)/2}^{|m|} \left(\frac{r^2}{\beta^2}\right) exp\left( -\frac{r^2}{2\beta^2} \right) exp(-im\theta) $$
 
     with 
     $$ \alpha_1 = \frac{(-1)^{(n-|m|)/2}}{\beta^{|m|+1}} $$
-    $$ \alpha_2 = \left\{ \frac{[(n-|m|)/2]!} {\pi[(n+|m|)/2]!} \right\}^{\frac{1}{2}} $$
+    $$ \alpha_2 = \left[ \frac{[(n-|m|)/2]!} {\pi[(n+|m|)/2]!} \right]^{\frac{1}{2}}  $$
 
-    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
+    where $\beta$ is the shapelet length scale, $L$ is the generalized (associated) laguerre polynomial[2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
 
     Parameters
     ----------
     * n: int
-        * Shapelet order. Acceptable values $n \geq 0$.
+        * Shapelet order. Acceptable values are $n \geq 0$
     * m: int
-        * Also describes shapelet order. Acceptable values $m \in [-n, n]$. However, if n is odd/even, m must be odd/even respectively.
-    * x1: float or np.ndarray
-        * First input to shapelet function.
-    * x2: float or np.ndarray
-        * Second input to shapelet function.
+        * Also describes shapelet order. Acceptable values $m \in [-n, n]$. However, if n is odd/even, m must also be odd/even respectively
+    * x1: Union[float,np.ndarray]
+        * First input to shapelet function
+    * x2: Union[float,np.ndarray]
+        * Second input to shapelet function
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1, x2): float or np.ndarray
-        * Shapelet function evaluated at (x1, x2).
+    * Sc(x1, x2): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1, x2)
 
     References
     ----------
@@ -185,35 +185,35 @@ def polar2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndar
 
     return Sc(x1, x2)
 
-def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
+def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
-    Orthonormal 2D polar shapelet function defined as [1]_,
+    Orthonormal 2D polar shapelet function defined as[1]_,
 
     $$ S_{m}(r, \theta; \beta) = \frac{1}{\beta \sqrt{\pi m!}} \left( \frac{r}{\beta} \right)^m exp \left( -\frac{r^2}{2\beta^2}-im\theta \right) $$
 
     with $$ \beta = \frac{fl}{\sqrt{m}} $$
 
-    where $\beta$ is the shapelet length scale, $f$ is a geometric scale factor, $l$ is the characteristic wavelength of the image (see [2]), and $m$ is the shapelet degree of rotational symmetry.
+    where $\beta$ is the shapelet length scale, $f$ is a geometric scale factor[1]_, $l$ is the characteristic wavelength of the image[2]_, and $m$ is the shapelet degree of rotational symmetry.
 
     Parameters
     ----------
     * m: int
-        * Shapelet degree of rotational symmetry. Acceptable values $m > 1$.
-    * x1: float or np.ndarray
-        * First input to shapelet function.
-    * x2: float or np.ndarray
-        * Second input to shapelet function.
+        * Shapelet degree of rotational symmetry. Acceptable values are $m > 1$
+    * x1: Union[float,np.ndarray]
+        * First input to shapelet function
+    * x2: Union[float,np.ndarray]
+        * Second input to shapelet function
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1, x2): float or np.ndarray
-        * Shapelet function evaluated at (x1, x2).
+    * Sc(x1, x2): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1, x2)
 
     Notes
     -----
-    The orthonormal shapelet framework [1]_ only supports $n = 0$. See ref [2]_ for computing the characteristic wavelength. Note that this shapelet formulation is a re-parameterization of that found in polar2D().
+    The orthonormal shapelet framework[1]_ only supports $n = 0$. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of that found in ``shapelets.functions.polar2D``.
 
     References
     ----------
@@ -238,29 +238,29 @@ def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.n
 
     return Sc(x1, x2)
 
-def exponential1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
+def exponential1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
-    1D exponential shapelet function defined as [1]_,
+    1D exponential shapelet function defined as[1]_,
 
     $$ S_n(x; \beta) = \alpha \frac{2x}{n\beta} L^{1}_{n-1} \left( \frac{2x}{n\beta} \right) exp\left( -\frac{x}{n\beta} \right) \forall x \geq 0 $$
 
     with $$ \alpha = \frac{(-1)^{n-1}}{\sqrt{n^3\beta}} $$
 
-    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order.
+    where $\beta$ is the shapelet length scale, $L$ is the generalized (associated) laguerre polynomial[2]_, and $n$ is the shapelet order.
 
     Parameters
     ----------
     * n: int
-        * Shapelet order. Must be non-negative. Acceptable values $n \geq 1$.
-    * x1: float or np.ndarray
-        * The input to the shapelet function. Acceptable values $x1 \geq 0$.
+        * Shapelet order. Must be non-negative. Acceptable values are $n \geq 1$
+    * x1: Union[float,np.ndarray]
+        * The input to the shapelet function. Acceptable values are $x1 \geq 0$
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1): float or numpy.ndarray
-        * Shapelet function evaluated at Sc(x1).
+    * Sc(x1): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1)
         
     References
     ----------
@@ -285,7 +285,7 @@ def exponential1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
 
     return Sc(x1)
 
-def exponential2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
+def exponential2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r"""
     2D exponential shapelet function defined as [1]_,
 
@@ -293,25 +293,25 @@ def exponential2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,n
 
     with $$ \alpha = \frac{(-1)^n}{(\beta(2n+1))^{|m|}} \sqrt{ \frac{2}{\beta\pi(2n+1)^3} \frac{(n-|m|)!}{(n+|m|)!} } $$
 
-    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
+    where $\beta$ is the shapelet length scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
 
     Parameters
     ----------
     * n: int
-        * Shapelet order. Must be non-negative. Acceptable values $n \geq 0$.
+        * Shapelet order. Must be non-negative. Acceptable values are $n \geq 0$
     * m: int
-        * Also describes shapelet order. Acceptable values $m \in [-n, n]$.
-    * x1: float or np.ndarray
-        * First input to shapelet function.
-    * x2: float or np.ndarray
-        * Second input to shapelet function.
+        * Also describes shapelet order. Acceptable values are $m \in [-n, n]$
+    * x1: Union[float,np.ndarray]
+        * First input to shapelet function
+    * x2: Union[float,np.ndarray]
+        * Second input to shapelet function
     * beta: float
-        * The characteristic shapelet length scale parameter.
+        * The shapelet length scale parameter
 
     Returns
     -------
-    * Sc(x1, x2): float or numpy.ndarray
-        * Shapelet function evaluated at (x1, x2).
+    * Sc(x1, x2): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1, x2)
 
     References
     ----------

--- a/shapelets/functions.py
+++ b/shapelets/functions.py
@@ -15,6 +15,8 @@
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
 
+from typing import Union
+
 import numpy as np
 from scipy.special import factorial, genlaguerre, hermite
 
@@ -27,35 +29,29 @@ __all__ = [
     'exponential2D'
 ]
 
-def cartesian1D(n, x1, beta = 1):
+def cartesian1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
     r""" 
-    1D cartesian shapelet function from [1].
+    1D cartesian shapelet function defined as [1]_,
 
-    Defined in 1D as [1]_,
+    $$ S_{n}(x; \beta) = \beta^{-\frac{1}{2}}  \phi_{n}(\frac{x}{\beta}) $$
 
-    .. math:: S_{n}(x; \beta) = \beta^{-\frac{1}{2}}  \phi_{n}(\frac{x}{\beta})
+    with $$ \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2}) $$
 
-    with
-    .. math:: \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2})
-
-    where :math:`\phi_n` is the dimensionless [shapelet] basis function,
-          :math:`\beta` is the characteristic shapelet scale,
-          :math:`H_n` is a hermite polynomial of order n, and
-          :math:`n` is the shapelet order.
+    where $\phi_n$ is the dimensionless [shapelet] basis function, $\beta$ is the characteristic shapelet scale, $H_n$ is a hermite polynomial of order n, and $n$ is the shapelet order.
 
     Parameters
     ----------
-    n : int
-        Shapelet order. Acceptable values :math:`n \geq 0`.
-    x1: float or np.ndarray
-        The input to the shapelet function.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * n: int
+        * Shapelet order. Acceptable values $n \geq 0$.
+    * x1: float or np.ndarray
+        * The input to the shapelet function.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1) : float or np.ndarray
-        Shapelet function evaluated with S(x1).
+    * Sc(x1): float or np.ndarray
+        * Shapelet function evaluated at S(x1).
 
     References
     ----------
@@ -76,39 +72,33 @@ def cartesian1D(n, x1, beta = 1):
 
     return Sc(x1)
 
-def cartesian2D(n1, n2, x1, x2, beta = 1):
+def cartesian2D(n1: int, n2: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
     r""" 
-    Cartesian shapelet function from [1].
+    2D cartesian shapelet function defined as [1]_,
 
-    Defined in 2D as [1]_,
+    $$ S_{n_1,n_2}(x_1, x_2; \beta) = \beta^{-1} \phi_{n_1}(\frac{x_1}{\beta}) \phi_{n_2}(\frac{x_2}{\beta}) $$
 
-    .. math:: S_{n_1,n_2}(x_1, x_2; \beta) = \beta^{-1} \phi_{n_1}(\frac{x_1}{\beta}) \phi_{n_2}(\frac{x_2}{\beta})
+    with $$ \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2}) $$
 
-    with
-    .. math:: \phi_n(x) = \left( 2^n \pi^{\frac{1}{2}} n! \right)^{-\frac{1}{2}} H_n(x) exp(-\frac{x^2}{2})
-
-    where :math:`\phi_n` is the dimensionless [shapelet] basis function,
-          :math:`\beta` is the characteristic shapelet scale,
-          :math:`H_n` is a hermite polynomial of order n, and
-          :math:`n_1` and :math:`n_2` are the shapelet orders.
+    where $\phi_n$ is the dimensionless [shapelet] basis function, $\beta$ is the characteristic shapelet scale, $H_n$ is a hermite polynomial of order n, and $n_1$ and $n_2$ are the shapelet orders.
 
     Parameters
     ----------
-    n1 : int
-        Shapelet order in x direction. Acceptable values :math:`n1 \geq 0`.
-    n2 : int
-        Shapelet order in y direction. Acceptable values :math:`n2 \geq 0`.
-    x1 : float or np.ndarray
-        First input to shapelet function.
-    x2 : float or np.ndarray
-        Second input to shapelet function.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * n1: int
+        * Shapelet order in x direction. Acceptable values $n1 \geq 0$.
+    * n2: int
+        * Shapelet order in y direction. Acceptable values $n2 \geq 0$.
+    * x1: float or np.ndarray
+        * First input to shapelet function.
+    * x2: float or np.ndarray
+        * Second input to shapelet function.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1, x2) : float or np.ndarray
-        Returns continuous shapelet evaluated with (x1, x2).
+    * Sc(x1, x2): float or np.ndarray
+        * Shapelet function evaluated at (x1, x2).
 
     References
     ----------
@@ -132,43 +122,35 @@ def cartesian2D(n1, n2, x1, x2, beta = 1):
 
     return Sc(x1, x2)
 
-def polar2D(n, m, x1, x2, beta = 1):
+def polar2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
     r""" 
-    2D polar shapelet function from [1].
+    2D polar shapelet function defined as [1]_,
 
-    Defined as [1]_,
+    $$ S_{n, m}(r, \theta; \beta) = \alpha_1 \alpha_2 r^{|m|} L_{(n-|m|)/2}^{|m|} \left(\frac{r^2}{\beta^2}\right) exp\left( -\frac{r^2}{2\beta^2} \right) exp(-im\theta) $$
 
-    .. math:: S_{n, m}(r, \theta; \beta) = \alpha_1 \alpha_2 r^{|m|} L_{(n-|m|)/2}^{|m|}
-                                           \left(\frac{r^2}{\beta^2}\right)
-                                           exp\left( -\frac{r^2}{2\beta^2} \right)
-                                           exp(-im\theta)
+    with 
+    $$ \alpha_1 = \frac{(-1)^{(n-|m|)/2}}{\beta^{|m|+1}} $$
+    $$ \alpha_2 = \left\{ \frac{[(n-|m|)/2]!} {\pi[(n+|m|)/2]!} \right\}^{\frac{1}{2}} $$
 
-    with
-    .. math:: \alpha_1 = \frac{(-1)^{(n-|m|)/2}}{\beta^{|m|+1}}
-    .. math:: \alpha_2 = \left\{ \frac{[(n-|m|)/2]!} {\pi[(n+|m|)/2]!} \right\}^{\frac{1}{2}}
-
-    where :math:`\beta` is the characteristic shapelet scale,
-          :math:`L` is the generalized (associated) laguerre polynomial [2],
-          :math:`n` is the shapelet order, and
-          :math:`m` is also the shapelet order.
+    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
 
     Parameters
     ----------
-    n : int
-        Shapelet order. Acceptable values :math:`n \geq 0`.
-    m : int
-        Also describes shapelet order. Acceptable values :math:`m \in [-n, n]`. However, if n is odd/even, m must be odd/even respectively.
-    x1 : float or np.ndarray
-        First input to shapelet function.
-    x2 : float or np.ndarray
-        Second input to shapelet function.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * n: int
+        * Shapelet order. Acceptable values $n \geq 0$.
+    * m: int
+        * Also describes shapelet order. Acceptable values $m \in [-n, n]$. However, if n is odd/even, m must be odd/even respectively.
+    * x1: float or np.ndarray
+        * First input to shapelet function.
+    * x2: float or np.ndarray
+        * Second input to shapelet function.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1, x2) : float  or np.ndarray
-        Returns continuous shapelet evaluated with (x1, x2).
+    * Sc(x1, x2): float or np.ndarray
+        * Shapelet function evaluated at (x1, x2).
 
     References
     ----------
@@ -203,43 +185,35 @@ def polar2D(n, m, x1, x2, beta = 1):
 
     return Sc(x1, x2)
 
-def orthonormalpolar2D(m, x1, x2, beta = 1):
+def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
     r""" 
-    Orthonormal 2D polar shapelet function from [1].
+    Orthonormal 2D polar shapelet function defined as [1]_,
 
-    Defined as [1]_,
+    $$ S_{m}(r, \theta; \beta) = \frac{1}{\beta \sqrt{\pi m!}} \left( \frac{r}{\beta} \right)^m exp \left( -\frac{r^2}{2\beta^2}-im\theta \right) $$
 
-    .. math:: S_{m}(r, \theta; \beta) = \frac{1}{\beta \sqrt{\pi m!}}
-                                        \left( \frac{r}{\beta} \right)^m exp
-                                        \left( -\frac{r^2}{2\beta^2}-im\theta \right)
+    with $$ \beta = \frac{fl}{\sqrt{m}} $$
 
-    with
-    .. math:: \beta = \frac{fl}{\sqrt{m}}
-
-    where :math:`\beta` is the shapelet length scale,
-          :math:`f` is a geometric scale factor,
-          :math:`l` is the characteristic wavelength of the image (see [2]), and
-          :math:`m` is the shapelet degree of rotational symmetry.
+    where $\beta$ is the shapelet length scale, $f$ is a geometric scale factor, $l$ is the characteristic wavelength of the image (see [2]), and $m$ is the shapelet degree of rotational symmetry.
 
     Parameters
     ----------
-    m : int
-        Shapelet degree of rotational symmetry. Acceptable values :math:`m > 1`.
-    x1 : float or np.ndarray
-        First input to shapelet function.
-    x2 : float or np.ndarray
-        Second input to shapelet function.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * m: int
+        * Shapelet degree of rotational symmetry. Acceptable values $m > 1$.
+    * x1: float or np.ndarray
+        * First input to shapelet function.
+    * x2: float or np.ndarray
+        * Second input to shapelet function.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1, x2) : float or np.ndarray
-        Returns continuous shapelet evaluated with (x1, x2).
+    * Sc(x1, x2): float or np.ndarray
+        * Shapelet function evaluated at (x1, x2).
 
     Notes
     -----
-    The orthonormal shapelet framework from [1] only supports n = 0. See [2] for computing the characteristic wavelength. Note that this shapelet formulation is a re-parameterization of that found in polar2D().
+    The orthonormal shapelet framework [1]_ only supports $n = 0$. See ref [2]_ for computing the characteristic wavelength. Note that this shapelet formulation is a re-parameterization of that found in polar2D().
 
     References
     ----------
@@ -264,35 +238,29 @@ def orthonormalpolar2D(m, x1, x2, beta = 1):
 
     return Sc(x1, x2)
 
-def exponential1D(n, x1, beta = 1):
+def exponential1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.):
     r""" 
-    1D exponential shapelet function from [1].
+    1D exponential shapelet function defined as [1]_,
 
-    Defined in 1D as [1]_,
+    $$ S_n(x; \beta) = \alpha \frac{2x}{n\beta} L^{1}_{n-1} \left( \frac{2x}{n\beta} \right) exp\left( -\frac{x}{n\beta} \right) \forall x \geq 0 $$
 
-    .. math:: S_n(x; \beta) = \alpha \frac{2x}{n\beta} L^{1}_{n-1} \left( \frac{2x}{n\beta} \right)
-                              exp\left( -\frac{x}{n\beta} \right) \forall x \geq 0
+    with $$ \alpha = \frac{(-1)^{n-1}}{\sqrt{n^3\beta}} $$
 
-    with
-    .. math:: \alpha = \frac{(-1)^{n-1}}{\sqrt{n^3\beta}}
-
-    where :math:`\beta` is the characteristic shapelet scale,
-          :math:`L` is the generalized (associated) laguerre polynomial [2],
-          :math:`n` is the shapelet order.
+    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order.
 
     Parameters
     ----------
-    n : int
-        Shapelet order. Must be non-negative. Acceptable values :math:`n \geq 1`.
-    x1 : float or np.ndarray
-        The input to the shapelet function. Acceptable values :math:`x1 \geq 0`.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * n: int
+        * Shapelet order. Must be non-negative. Acceptable values $n \geq 1$.
+    * x1: float or np.ndarray
+        * The input to the shapelet function. Acceptable values $x1 \geq 0$.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1) : float or numpy.ndarray
-        Shapelet function evaluated with Sc(x1).
+    * Sc(x1): float or numpy.ndarray
+        * Shapelet function evaluated at Sc(x1).
         
     References
     ----------
@@ -317,41 +285,33 @@ def exponential1D(n, x1, beta = 1):
 
     return Sc(x1)
 
-def exponential2D(n, m, x1, x2, beta = 1):
+def exponential2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.):
     r"""
-    2D exponential shapelet function from [1].
+    2D exponential shapelet function defined as [1]_,
 
-    Defined in 2D as [1]_,
+    $$ S_{n,m}(r, \theta; \beta) = \alpha (2r)^{|m|} L^{2|m|}_{n-|m|}\left( \frac{2r}{\beta(2n+1)} \right) exp\left( -\frac{r}{\beta(2n+1)} \right) exp(-im\theta) $$
 
-    ..math:: S_{n,m}(r, \theta; \beta) = \alpha (2r)^{|m|} L^{2|m|}_{n-|m|}\left( \frac{2r}{\beta(2n+1)} \right)
-                                         exp\left( -\frac{r}{\beta(2n+1)} \right) exp(-im\theta)
+    with $$ \alpha = \frac{(-1)^n}{(\beta(2n+1))^{|m|}} \sqrt{ \frac{2}{\beta\pi(2n+1)^3} \frac{(n-|m|)!}{(n+|m|)!} } $$
 
-    with
-    .. math:: \alpha = \frac{(-1)^n}{(\beta(2n+1))^{|m|}} \sqrt{ \frac{2}{\beta\pi(2n+1)^3}
-                       \frac{(n-|m|)!}{(n+|m|)!} }
-
-    where :math:`\beta` is the characteristic shapelet scale,
-          :math:`L` is the generalized (associated) laguerre polynomial [2],
-          :math:`n` is the shapelet order, and
-          :math:`m` is also the shapelet order.
+    where $\beta$ is the characteristic shapelet scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
 
     Parameters
     ----------
-    n : int
-        Shapelet order. Must be non-negative. Acceptable values :math:`n \geq 0`.
-    m : int
-        Also describes shapelet order. Acceptable values :math:`m \in [-n, n]`.
-    x1 : float or np.ndarray
-        First input to shapelet function.
-    x2 : float or np.ndarray
-        Second input to shapelet function.
-    beta : float
-        The characteristic shapelet length scale parameter.
+    * n: int
+        * Shapelet order. Must be non-negative. Acceptable values $n \geq 0$.
+    * m: int
+        * Also describes shapelet order. Acceptable values $m \in [-n, n]$.
+    * x1: float or np.ndarray
+        * First input to shapelet function.
+    * x2: float or np.ndarray
+        * Second input to shapelet function.
+    * beta: float
+        * The characteristic shapelet length scale parameter.
 
     Returns
     -------
-    Sc(x1, x2) : float or numpy.ndarray
-        Returns continuous shapelet evaluated with (x1, x2).
+    * Sc(x1, x2): float or numpy.ndarray
+        * Shapelet function evaluated at (x1, x2).
 
     References
     ----------

--- a/shapelets/functions.py
+++ b/shapelets/functions.py
@@ -157,8 +157,7 @@ def polar2D(n, m, x1, x2, beta = 1):
     n : int
         Shapelet order. Acceptable values :math:`n \geq 0`.
     m : int
-        Also describes shapelet order. Acceptable values :math:`m \in [-n, n]`.
-        However, if n is odd/even, m must be odd/even respectively.
+        Also describes shapelet order. Acceptable values :math:`m \in [-n, n]`. However, if n is odd/even, m must be odd/even respectively.
     x1 : float or np.ndarray
         First input to shapelet function.
     x2 : float or np.ndarray
@@ -240,10 +239,7 @@ def orthonormalpolar2D(m, x1, x2, beta = 1):
 
     Notes
     -----
-    The orthonormal shapelet framework from [1] only supports n = 0.
-    See [2] for computing the characteristic wavelength.
-    Note that this shapelet formulation is a re-parameterization 
-        of that found in polar2D().
+    The orthonormal shapelet framework from [1] only supports n = 0. See [2] for computing the characteristic wavelength. Note that this shapelet formulation is a re-parameterization of that found in polar2D().
 
     References
     ----------
@@ -297,6 +293,7 @@ def exponential1D(n, x1, beta = 1):
     -------
     Sc(x1) : float or numpy.ndarray
         Shapelet function evaluated with Sc(x1).
+        
     References
     ----------
     .. [1] https://doi.org/10.1093/mnras/stz787

--- a/shapelets/functions.py
+++ b/shapelets/functions.py
@@ -213,7 +213,7 @@ def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.n
 
     Notes
     -----
-    The orthonormal shapelet framework[1]_ only supports $n = 0$. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of that found in ``shapelets.functions.polar2D``.
+    The orthonormal shapelet framework[1]_ only supports $n = 0$. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of that found in shapelets.functions.polar2D.
 
     References
     ----------
@@ -287,13 +287,13 @@ def exponential1D(n: int, x1: Union[float,np.ndarray], beta: float = 1.) -> Unio
 
 def exponential2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r"""
-    2D exponential shapelet function defined as [1]_,
+    2D exponential shapelet function defined as[1]_,
 
     $$ S_{n,m}(r, \theta; \beta) = \alpha (2r)^{|m|} L^{2|m|}_{n-|m|}\left( \frac{2r}{\beta(2n+1)} \right) exp\left( -\frac{r}{\beta(2n+1)} \right) exp(-im\theta) $$
 
     with $$ \alpha = \frac{(-1)^n}{(\beta(2n+1))^{|m|}} \sqrt{ \frac{2}{\beta\pi(2n+1)^3} \frac{(n-|m|)!}{(n+|m|)!} } $$
 
-    where $\beta$ is the shapelet length scale, $L$ is the generalized (associated) laguerre polynomial [2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
+    where $\beta$ is the shapelet length scale, $L$ is the generalized (associated) laguerre polynomial[2]_, $n$ is the shapelet order, and $m$ is also the shapelet order.
 
     Parameters
     ----------

--- a/shapelets/run.py
+++ b/shapelets/run.py
@@ -31,12 +31,12 @@ def run(config_file: str) -> None:
     
     Parameters
     ----------
-    config_file : str
-        The name of the config file.
+    * config_file : str
+        * The name of the configuration file
     
     Notes
     -----
-    Differentiation between submodule use is based on image_name or fits_name provided in config file this may need to be changed in the future if more astronomy functionality is added.
+    Differentiation between submodule use is based on image_name or fits_name provided in config file. Note that this may need to be changed in the future if more astronomy functionality is added.
 
     """
     ## configparser setup and input/output path organization ##

--- a/shapelets/run.py
+++ b/shapelets/run.py
@@ -27,7 +27,6 @@ from .self_assembly.wavelength import *
 
 def run(config_file: str) -> None:
     r""" 
-    
     Main run function that handles input configuration file.
     
     Parameters

--- a/shapelets/run.py
+++ b/shapelets/run.py
@@ -37,8 +37,7 @@ def run(config_file: str) -> None:
     
     Notes
     -----
-    Differentiation between submodule use is based on image_name or fits_name provided in config file
-        ...this may need to be changed in the future if more astronomy functionality is added.
+    Differentiation between submodule use is based on image_name or fits_name provided in config file this may need to be changed in the future if more astronomy functionality is added.
 
     """
     ## configparser setup and input/output path organization ##
@@ -86,16 +85,14 @@ def run(config_file: str) -> None:
 
             response = convresponse(image = image, l = char_wavelength, shapelet_order = shapelet_order, normresponse = 'Vector')[0]
             rd_field = rdistance(image = image, response = response, num_clusters = num_clusters, ux = ux, uy = uy)
-            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance',
-                           d = rd_field, num_clusters = num_clusters)
+            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)
 
         elif method == 'orientation':
             pattern_order = config.get('orientation', 'pattern_order')
 
             response, orients = convresponse(image = image, l = char_wavelength, shapelet_order = 6, normresponse = 'Individual')
             mask, dilate, blended, maxval = orientation(pattern_order = pattern_order, l = char_wavelength, response = response, orients = orients)
-            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation',
-                           mask = mask, dilate = dilate, orientation = blended, maxval = maxval)
+            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)
     
         elif method == 'identify_defects':
             pattern_order = config.get('identify_defects', 'pattern_order')
@@ -107,12 +104,10 @@ def run(config_file: str) -> None:
             response = convresponse(image = image, l = char_wavelength, shapelet_order = 'default', normresponse = 'Vector')[0]
             centroids, clusterMembers, defects = defectid(response = response, l = char_wavelength,
                                                           pattern_order = pattern_order, num_clusters = num_clusters)
-            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects',
-                           centroids = centroids, clusterMembers = clusterMembers, defects = defects)
+            process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)
         
         else:
             raise ValueError('"method" parameter from configuration file not recognized by shapelets.')
-
 
     ## astronomy submodule use ##
         

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -50,9 +50,7 @@ def make_grid(N: int):
     
     Notes
     -----
-    As per convention, N should only be an odd number.
-    Additionally, note that grid_x == grid_y (identical for obvious
-        reasons).
+    As per convention, N should only be an odd number. Additionally, note that grid_x == grid_y (identical for obvious reasons).
 
     """
     if N % 2 == 0:
@@ -86,8 +84,7 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
 
     Notes
     -----
-    The bounds for either threshold (-1, 1) are intentional to align with 
-    the minimum and maximum of shapelet function intensity.
+    The bounds for either threshold (-1, 1) are intentional to align with the minimum and maximum of shapelet function intensity.
     
     """
     if os.path.exists(image_path):
@@ -110,17 +107,13 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
 def process_output(image: np.ndarray, image_name: str, save_path: str, output_from: str, **kwargs) -> None:
     r""" 
     Processes and saves output from any of the functions below,
-        * shapelets.self_assembly.quant.rdistance()
-        * shapelets.self_assembly.quant.orientation()
-        * shapelets.self_assembly.quant.defectid()
+    * shapelets.self_assembly.quant.rdistance()
+    * shapelets.self_assembly.quant.orientation()
+    * shapelets.self_assembly.quant.defectid()
     
     It was used to generate Figures 6, 7, 8, and 9 from [1].
 
-    NOTE: any image saved from the **kwargs argument is trimmed using 
-        shapelets.self_assembly.misc.trim_image().
-        This is because the convolution with shapelet kernels is padded on
-        the edges, producing a fuzzy convolutional response.
-        The trim_image() function removes this fuzzy response.
+    NOTE: any image saved from the **kwargs argument is trimmed using shapelets.self_assembly.misc.trim_image(). This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The trim_image() function removes this fuzzy response.
 
     Parameters
     ----------
@@ -131,8 +124,7 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
     save_path : str
         The path to save results.
     output_from : str
-        The name of the method for which we will process and save the output/results.
-        Options are: 'response_distance', 'orientation', or 'identify_defects'
+        The name of the method for which we will process and save the output/results. Options are: 'response_distance', 'orientation', or 'identify_defects'
 
     Notes
     -----
@@ -306,8 +298,7 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
 
 def image_difference(im1: np.ndarray, im2: np.ndarray):
     r""" 
-    This function computes the normalized difference between two images.
-    It was used to generate Figure 5 from [1].
+    This function computes the normalized difference between two images. It was used to generate Figure 5 from [1].
 
     Parameters
     ----------
@@ -344,8 +335,7 @@ def image_difference(im1: np.ndarray, im2: np.ndarray):
 
 def trim_image(im: np.ndarray, l: float):
     r""" 
-    Trim image edges based on characteristic wavelength (l). 
-    Useful for images post convolution, as edges can present distortions.
+    Trim image edges based on characteristic wavelength (l). Useful for images post convolution, as edges can present distortions because of padded convolution.
 
     Parameters
     ----------
@@ -360,8 +350,7 @@ def trim_image(im: np.ndarray, l: float):
 
     Notes
     -----
-    The characteristic wavelength is roughly the distance between feature centers,
-    thus making it an appropriate size for image trim or truncation after convolution.
+    The characteristic wavelength is roughly the distance between feature centers, thus making it an appropriate size for image trim or truncation after convolution. 
 
     """
     trim = int(l)

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -109,13 +109,13 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
 def process_output(image: np.ndarray, image_name: str, save_path: str, output_from: str, **kwargs) -> None:
     r""" 
     Processes and saves output from any of the functions below,
-    * ``shapelets.self_assembly.quant.rdistance``
-    * ``shapelets.self_assembly.quant.orientation``
-    * ``shapelets.self_assembly.quant.defectid``
+    * shapelets.self_assembly.quant.rdistance
+    * shapelets.self_assembly.quant.orientation
+    * shapelets.self_assembly.quant.defectid
     
-    It was used to generate Figures 6, 7, 8, and 9 from ref [1]_.
+    It was used to generate Figures 6, 7, 8, and 9 from ref.[1]_.
 
-    NOTE: any image saved from the **kwargs argument is trimmed using ``shapelets.self_assembly.misc.trim_image``. This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The ``shapelets.self_assembly.misc.trim_image`` function removes this fuzzy response.
+    NOTE: any image saved from the **kwargs argument is trimmed using shapelets.self_assembly.misc.trim_image. This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The shapelets.self_assembly.misc.trim_image function removes this fuzzy response.
 
     Parameters
     ----------
@@ -131,9 +131,9 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
     Notes
     -----
     Required kwargs are,
-    * output_from = 'response_distance'   -->     d, num_clusters (see ``shapelets.self_assembly.quant.rdistance``)
-    * output_from = 'orientation'         -->     mask, dilate, orientation, maxval (see ``shapelets.self_assembly.quant.orientation``)
-    * output_from = 'identify_defects'    -->     defects, centroids, clusterMembers (see ``shapelets.self_assembly.quant.defectid``)
+    * output_from = 'response_distance'   -->     d, num_clusters (see shapelets.self_assembly.quant.rdistance)
+    * output_from = 'orientation'         -->     mask, dilate, orientation, maxval (see shapelets.self_assembly.quant.orientation)
+    * output_from = 'identify_defects'    -->     defects, centroids, clusterMembers (see shapelets.self_assembly.quant.defectid)
 
     References
     ----------

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -29,6 +29,7 @@ __all__ = [
     'make_grid',
     'read_image',
     'process_output',
+    'image_difference',
     'trim_image'
 ]
 
@@ -50,11 +51,12 @@ def make_grid(N: int):
     
     Notes
     -----
-    As per convention, N should only be an odd number. Additionally, note that grid_x == grid_y (identical for obvious reasons).
+    As per convention, N should only be an odd number. Additionally, note that grid_x = grid_y.
 
     """
     if N % 2 == 0:
-        raise ValueError('N must be an odd number, not even.')
+        print('Detected even grid size, adding 1 to enforce odd rule See self_assembly.misc.make_grid() docs.')
+        N += 1
     if N < 3:
         raise ValueError('N must be at least 3 or greater.')
     
@@ -66,7 +68,7 @@ def make_grid(N: int):
 
 def read_image(image_name: str, image_path: str, verbose: bool = True):
     r""" 
-    Read an image using cv2 (OpenCV) with some extra handling.
+    Read an image using OpenCV, with some extra handling. By default, re-scales images as greyscale on [-1, 1].
     
     Parameters
     ----------
@@ -74,17 +76,17 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
         * The filename of the image (including extension)
     * image_path: str
         * The path holding the image
-    * verbose: bool
-        * True to print image-related information
+    * verbose: bool, optional
+        * True (default) to print image-related information
     
     Returns
     -------
     * f: np.ndarray
-        * The image as a numpy array.
+        * The image as a numpy.ndarray.
 
     Notes
     -----
-    The bounds for either threshold (-1, 1) are intentional to align with the minimum and maximum of shapelet function intensity.
+    Re-scaling of image to greyscale on [-1, 1] is intentional to align with the minimum and maximum of shapelet function values.
     
     """
     if os.path.exists(image_path):
@@ -107,13 +109,13 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
 def process_output(image: np.ndarray, image_name: str, save_path: str, output_from: str, **kwargs) -> None:
     r""" 
     Processes and saves output from any of the functions below,
-    * shapelets.self_assembly.quant.rdistance()
-    * shapelets.self_assembly.quant.orientation()
-    * shapelets.self_assembly.quant.defectid()
+    * ``shapelets.self_assembly.quant.rdistance``
+    * ``shapelets.self_assembly.quant.orientation``
+    * ``shapelets.self_assembly.quant.defectid``
     
     It was used to generate Figures 6, 7, 8, and 9 from ref [1]_.
 
-    NOTE: any image saved from the **kwargs argument is trimmed using shapelets.self_assembly.misc.trim_image(). This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The trim_image() function removes this fuzzy response.
+    NOTE: any image saved from the **kwargs argument is trimmed using ``shapelets.self_assembly.misc.trim_image``. This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The ``shapelets.self_assembly.misc.trim_image`` function removes this fuzzy response.
 
     Parameters
     ----------
@@ -129,9 +131,9 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
     Notes
     -----
     Required kwargs are,
-    * output_from = 'response_distance'   -->     d, num_clusters
-    * output_from = 'orientation'         -->     mask, dilate, orientation, maxval
-    * output_from = 'identify_defects'    -->     defects, centroids, clusterMembers
+    * output_from = 'response_distance'   -->     d, num_clusters (see ``shapelets.self_assembly.quant.rdistance``)
+    * output_from = 'orientation'         -->     mask, dilate, orientation, maxval (see ``shapelets.self_assembly.quant.orientation``)
+    * output_from = 'identify_defects'    -->     defects, centroids, clusterMembers (see ``shapelets.self_assembly.quant.defectid``)
 
     References
     ----------
@@ -298,7 +300,7 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
 
 def image_difference(im1: np.ndarray, im2: np.ndarray):
     r""" 
-    This function computes the normalized difference between two images. It was used to generate Figure 5 from ref [1]_.
+    This function computes the normalized difference between two images. It was used to generate Figure 5 from ref.[1]_.
 
     Parameters
     ----------
@@ -342,7 +344,7 @@ def trim_image(im: np.ndarray, l: float):
     * im: np.ndarray
         * The image to trim
     * l: float
-        * The characteristic wavelength
+        * The characteristic wavelength of the image[1]_
     
     Returns
     -------
@@ -350,7 +352,11 @@ def trim_image(im: np.ndarray, l: float):
 
     Notes
     -----
-    The characteristic wavelength is roughly the distance between feature centers, thus making it an appropriate size for image trim or truncation after convolution. 
+    The characteristic wavelength[1]_ is roughly the distance between feature centers, thus making it an appropriate size for image trim or truncation after convolution.
+
+    References
+    ----------
+    .. [1] http://dx.doi.org/10.1103/PhysRevE.91.033307
 
     """
     trim = int(l)

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -38,15 +38,15 @@ def make_grid(N: int):
     
     Parameters
     ----------
-    N : int
-        The width of the kernel (odd numbers only)
+    * N: int
+        * The width of the kernel (odd numbers only)
 
     Returns
     -------
-    grid_x : np.ndarray
-        The grid's x coordinate space
-    grid_y : np.ndarray
-        The grid's y coordinate space
+    * grid_x: np.ndarray
+        * The grid's x coordinate space
+    * grid_y: np.ndarray
+        * The grid's y coordinate space
     
     Notes
     -----
@@ -70,17 +70,17 @@ def read_image(image_name: str, image_path: str, verbose: bool = True):
     
     Parameters
     ----------
-    image_name : str
-        The filename of the image (including extension).
-    image_path : str
-        The path holding the image.
-    verbose : bool
-        True to print image-related information.
+    * image_name: str
+        * The filename of the image (including extension)
+    * image_path: str
+        * The path holding the image
+    * verbose: bool
+        * True to print image-related information
     
     Returns
     -------
-    f : np.ndarray
-        The image as a numpy array.
+    * f: np.ndarray
+        * The image as a numpy array.
 
     Notes
     -----
@@ -111,20 +111,20 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
     * shapelets.self_assembly.quant.orientation()
     * shapelets.self_assembly.quant.defectid()
     
-    It was used to generate Figures 6, 7, 8, and 9 from [1].
+    It was used to generate Figures 6, 7, 8, and 9 from ref [1]_.
 
     NOTE: any image saved from the **kwargs argument is trimmed using shapelets.self_assembly.misc.trim_image(). This is because the convolution with shapelet kernels is padded on the edges, producing a fuzzy convolutional response. The trim_image() function removes this fuzzy response.
 
     Parameters
     ----------
-    image : numpy.ndarray
-        The image loaded as a numpy array.
-    image_name : str
-        The name of the loaded image.
-    save_path : str
-        The path to save results.
-    output_from : str
-        The name of the method for which we will process and save the output/results. Options are: 'response_distance', 'orientation', or 'identify_defects'
+    * image: numpy.ndarray
+        * The image loaded as a numpy array
+    * image_name: str
+        * The name of the loaded image
+    * save_path: str
+        * The path to save results
+    * output_from: str
+        * The name of the method for which we will process and save the output/results. Options are: 'response_distance', 'orientation', or 'identify_defects'
 
     Notes
     -----
@@ -298,19 +298,19 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
 
 def image_difference(im1: np.ndarray, im2: np.ndarray):
     r""" 
-    This function computes the normalized difference between two images. It was used to generate Figure 5 from [1].
+    This function computes the normalized difference between two images. It was used to generate Figure 5 from ref [1]_.
 
     Parameters
     ----------
-    im1 : np.ndarray
-        The first image.
-    im2 : np.ndarray
-        The second image.
+    * im1: np.ndarray
+        * The first image
+    * im2: np.ndarray
+        * The second image
         
     Returns
     -------
-    diff : np.ndarray
-        The normalized difference in the input images.
+    * diff: np.ndarray
+        * The normalized difference in the input images
 
     Notes
     -----
@@ -339,14 +339,14 @@ def trim_image(im: np.ndarray, l: float):
 
     Parameters
     ----------
-    im : np.ndarray
-        The image to trim.
-    l : float
-        The characteristic wavelength
+    * im: np.ndarray
+        * The image to trim
+    * l: float
+        * The characteristic wavelength
     
     Returns
     -------
-    The trimmed image.
+    The trimmed image
 
     Notes
     -----

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -44,9 +44,9 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
     * image: np.ndarray
         * The image to be convolved with shapelet kernels
     * l: float
-        * The characteristic wavelength of the image [1]_
+        * The characteristic wavelength of the image[1]_
     * shapelet_order: Union[str,int]
-        * Set as 'default' to use higher-order shapelets [3]_ ($m \leq m'$). Can also accept integer value such that analysis uses $m \in [1, shapelet_{order}]$
+        * Set as 'default' to use higher-order shapelets[3]_ ($m \leq m'$). Can also accept integer value such that analysis uses $m \in [1, shapelet_{order}]$
     * normresponse: str, optional
         * Normalize magnitude of response (omega) in terms of response vectors = "Vector" (default). Normalize each m-fold response w.r.t itself on [0, 1) = "Individual"
     * verbose: bool, optional
@@ -61,7 +61,7 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
 
     Notes
     -----
-    This function uses the orthonormal polar shapelet definition [2]_ (see ``shapelets.functions.orthonormalpolar2D``).
+    This function uses the orthonormal polar shapelet definition[2]_ (see shapelets.functions.orthonormalpolar2D).
 
     References
     ----------
@@ -194,22 +194,22 @@ def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: U
     Parameters
     ----------
     * response: np.ndarray
-        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from shapelets.self_assembly.quant.convresponse
     * l: float
         * The characteristic wavelength of the image
     * pattern_order: str
         * Pattern order (symmetry type). Options are: 'stripe', 'square', 'hexagonal'
     * num_clusters: str or int
-        * The number of clusters as input to k-means clustering [2]_. Use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively
+        * The number of clusters as input to k-means clustering[2]_. Use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively
     
     Returns
     -------
     * centroids: np.ndarray
-        * The centroids from k-means clustering [2]_. Each centroid is a row vector
+        * The centroids from k-means clustering[2]_. Each centroid is a row vector
     * clusterMembers2D: np.ndarray
         * Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster who's centroid is centroids[1]
     * defects: np.ndarray
-        The result of the defect response distance method [1]_
+        The result of the defect response distance method[1]_
 
     References
     ----------
@@ -310,9 +310,9 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
     * l: float
         * The characteristic wavelength of the image
     * response: np.ndarray
-        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from shapelets.self_assembly.quant.convresponse
     * orients: np.ndarray
-        * The optimal shapelet filter orientation at maximum response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
+        * The optimal shapelet filter orientation at maximum response as a 3D array, obtained from shapelets.self_assembly.quant.convresponse
     * verbose: bool, optional
         * True (default) to print out results of orientation algorithm to console
 
@@ -329,7 +329,7 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
     
     Notes
     -----
-    This function uses ``shapelets.self_assembly.misc.trim_image`` during iteration to converge on an acceptable orientation result. Therefore, the orientation result will **not** have the same shape as the original image.
+    This function uses shapelets.self_assembly.misc.trim_image during iteration to converge on an acceptable orientation result. Therefore, the orientation result will **not** have the same shape as the original image.
 
     References
     ----------
@@ -403,9 +403,9 @@ def rdistance(image: np.ndarray, response: np.ndarray, num_clusters: Union[str,i
     * image: numpy.ndarray
         * The image loaded as a numpy array
     * response: np.ndarray
-        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from shapelets.self_assembly.quant.convresponse
     * num_clusters: Union[str,int]
-        * The number of clusters as input to k-means clustering [3]_. If str, acceptable value is "default" (which uses 20 clusters[2]_)
+        * The number of clusters as input to k-means clustering[3]_. If str, acceptable value is "default" (which uses 20 clusters[2]_)
     * ux: Union[str,list]
         * The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region during runtime
     * uy: Union[str,list]

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -41,27 +41,27 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
     
     Parameters
     ----------
-    image : numpy.ndarray
-        The image to be convolved with shapelet kernels.
-    l : float
-        The characteristic wavelength of the image.
-    shapelet_order : str or int
-        'default' to use higher-order shapelets (m<=m') as in ref [3]. Can also accept integer value to use shapelets for m = [1, shapelet_order].
-    normresponse : str, optional
-        Normalize magnitude of response (omega) in terms of response vectors = "Vector". Default. Normalize each m-fold response wrt itself on [0, 1) = "Individual".
-    verbose: bool
-        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
+    * image: numpy.ndarray
+        * The image to be convolved with shapelet kernels
+    * l: float
+        * The characteristic wavelength of the image
+    * shapelet_order: str or int
+        * 'default' to use higher-order shapelets (m<=m') as in ref. [3]_. Can also accept integer value to use shapelets for m = [1, shapelet_order]
+    * normresponse: str, optional
+        * Normalize magnitude of response (omega) in terms of response vectors = "Vector". Default. Normalize each m-fold response wrt itself on [0, 1) = "Individual"
+    * verbose: bool, optional
+        * True (default) to print out results of orientation algorithm to console. False to not print any results or information to console
 
     Returns
     -------
-    omega : numpy.ndarray
-        The magnitude of response.
-    phi : numpy.ndarray
-        The shapelet orientation at maximum response on [0, 2pi/m).
+    * omega: numpy.ndarray
+        * The magnitude of response
+    * phi: numpy.ndarray
+        * The shapelet orientation at maximum response normalized to $[0, 2pi/m)$
 
     Notes
     -----
-    This function uses the orthonormal polar shapelet definition from [1].
+    This function uses the orthonormal polar shapelet definition from ref. [1]_.
 
     References
     ----------
@@ -189,27 +189,27 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
 
 def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: Union[str,int]):
     r""" 
-    Computes the defect identification method from [1].
+    Computes the defect identification method from ref. [1]_.
 
     Parameters
     ----------
-    response : np.ndarray
-        The 3D array corresponding to shapelet response from convresponse().
-    l : float
-        The characteristic wavelength of the image.
-    pattern_order : str
-        Pattern order. Options are: 'stripe', 'square', 'hexagonal'.
-    num_clusters : int or str
-        The number of clusters as input to k-means clustering [4]. Can use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively. 
+    * response: np.ndarray
+        * The 3D array corresponding to shapelet response from convresponse()
+    * l: float
+        * The characteristic wavelength of the image
+    * pattern_order: str
+        * Pattern order (symmetry type). Options are: 'stripe', 'square', 'hexagonal'
+    * num_clusters: str or int
+        * The number of clusters as input to k-means clustering [2]_. Can use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively
     
     Returns
     -------
-    centroids : np.ndarray
-        The centroids from k-means clustering [2]. Each centroid is a row vector.
-    clusterMembers2D : np.ndarray
-        Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster with centroid as centroids[1].
-    defects : np.ndarray
-        The result of the defect response distance method. See [1]. 
+    * centroids: np.ndarray
+        * The centroids from k-means clustering [2]_. Each centroid is a row vector
+    * clusterMembers2D: np.ndarray
+        * Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster that has centroid #1
+    * defects: np.ndarray
+        The result of the defect response distance method. See ref. [1]_.
 
     References
     ----------
@@ -301,35 +301,35 @@ def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: U
 
 def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.ndarray, verbose: bool = True):
     r""" 
-    Finds the local pattern orientation using shapelet orientation at max response via an iterative scheme from [1].
+    Finds the local pattern orientation using shapelet orientation at max response via an iterative scheme from ref. [1]_.
 
     Parameters
     ----------
-    pattern_order : str
-        Pattern order. Options are: 'stripe', 'square', 'hexagonal'.
-    l : float
-        The characteristic wavelength of the image.
-    response : np.ndarray
-        The 3D array corresponding to shapelet response from convresponse().
-    orients : np.ndarray
-        The 3D array corresponding to the orientation at max response, obtained from convresponse().
-    verbose: bool
-        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
+    * pattern_order: str
+        * Pattern order (symmetry type). Options are: 'stripe', 'square', 'hexagonal'
+    * l: float
+        * The characteristic wavelength of the image
+    * response: np.ndarray
+        * The 3D array corresponding to shapelet response from convresponse()
+    * orients: np.ndarray
+        * The 3D array corresponding to the orientation at max response, obtained from convresponse()
+    * verbose: bool, optional
+        * True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
 
     Returns
     -------
-    mask : np.ndarray
-        The mask for well-defined features. See [1].
-    dilate : np.ndarray
-        The dilated mask. See [1].
-    orientation : np.ndarray
-        Applying smoothing/blending to the dilated mask via median filter kernel [2]. See [1].
-    maxval : float
-        The maximum allowed orientation value, where maxval = 2*np.pi / (m)
+    * mask: np.ndarray
+        * The mask for well-defined features. See ref. [1]_
+    * dilate: np.ndarray
+        * The dilated mask. See ref. [1]_
+    * orientation: np.ndarray
+        * Applying smoothing/blending to the dilated mask via median filter kernel [2]_. See ref. [1]_
+    * maxval: float
+        * The maximum allowed orientation value, where $maxval = 2*np.pi / m$
     
     Notes
     -----
-    This function uses shapelets.self_assembly.misc.trim_image during iteration to converge on an acceptable orientation result. 
+    This function uses ``shapelets.self_assembly.misc.trim_image`` during iteration to converge on an acceptable orientation result. 
 
     References
     ----------
@@ -395,27 +395,27 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
 
 def rdistance(image: np.ndarray, response: np.ndarray, num_clusters: Union[str,int], ux: Union[str,list] = 'default', uy: Union[str,list] = 'default', verbose: bool = True):
     r""" 
-    Compute the response distance method from [1] using the methodology described in [2].
+    Compute the response distance method from ref. [1]_ using the methodology described in ref. [2]_.
 
     Parameters
     ----------
-    image : numpy.ndarray
-        The image loaded as a numpy array.
-    response : np.ndarray
-        The 3D array corresponding to shapelet response from convresponse().
-    num_clusters : str or int
-        The number of clusters as input to k-means clustering [3]. If str, acceptable value is "default" (which uses 20).
-    ux : str or list
-        The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime.
-    uy : str or list
-        The bounds in the y-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime.
-    verbose: bool
-        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
+    * image: numpy.ndarray
+        * The image loaded as a numpy array
+    * response: np.ndarray
+        * The 3D array corresponding to shapelet response from convresponse()
+    * num_clusters: str or int
+        * The number of clusters as input to k-means clustering [3]_. If str, acceptable value is "default" (which uses 20)
+    * ux: str or list
+        * The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime
+    * uy: str or list
+        * The bounds in the y-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime
+    * verbose: bool, optional
+        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console
 
     Returns
     -------
-    d : np.ndarray
-        The response distance scalar field.
+    * d: np.ndarray
+        * The response distance scalar field.
 
     References
     ----------

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -41,27 +41,27 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
     
     Parameters
     ----------
-    * image: numpy.ndarray
+    * image: np.ndarray
         * The image to be convolved with shapelet kernels
     * l: float
-        * The characteristic wavelength of the image
-    * shapelet_order: str or int
-        * 'default' to use higher-order shapelets (m<=m') as in ref. [3]_. Can also accept integer value to use shapelets for m = [1, shapelet_order]
+        * The characteristic wavelength of the image [1]_
+    * shapelet_order: Union[str,int]
+        * Set as 'default' to use higher-order shapelets [3]_ ($m \leq m'$). Can also accept integer value such that analysis uses $m \in [1, shapelet_{order}]$
     * normresponse: str, optional
-        * Normalize magnitude of response (omega) in terms of response vectors = "Vector". Default. Normalize each m-fold response wrt itself on [0, 1) = "Individual"
+        * Normalize magnitude of response (omega) in terms of response vectors = "Vector" (default). Normalize each m-fold response w.r.t itself on [0, 1) = "Individual"
     * verbose: bool, optional
-        * True (default) to print out results of orientation algorithm to console. False to not print any results or information to console
+        * True (default) to print out information from convolution operation to console
 
     Returns
     -------
     * omega: numpy.ndarray
-        * The magnitude of response
+        * The magnitude of (maximum) convolutional response as a 3D array
     * phi: numpy.ndarray
         * The shapelet orientation at maximum response normalized to $[0, 2pi/m)$
 
     Notes
     -----
-    This function uses the orthonormal polar shapelet definition from ref. [1]_.
+    This function uses the orthonormal polar shapelet definition [2]_ (see ``shapelets.functions.orthonormalpolar2D``).
 
     References
     ----------
@@ -189,27 +189,27 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
 
 def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: Union[str,int]):
     r""" 
-    Computes the defect identification method from ref. [1]_.
+    Computes the defect identification method[1]_. Also known as the defect response distance method.
 
     Parameters
     ----------
     * response: np.ndarray
-        * The 3D array corresponding to shapelet response from convresponse()
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
     * l: float
         * The characteristic wavelength of the image
     * pattern_order: str
         * Pattern order (symmetry type). Options are: 'stripe', 'square', 'hexagonal'
     * num_clusters: str or int
-        * The number of clusters as input to k-means clustering [2]_. Can use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively
+        * The number of clusters as input to k-means clustering [2]_. Use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively
     
     Returns
     -------
     * centroids: np.ndarray
         * The centroids from k-means clustering [2]_. Each centroid is a row vector
     * clusterMembers2D: np.ndarray
-        * Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster that has centroid #1
+        * Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster who's centroid is centroids[1]
     * defects: np.ndarray
-        The result of the defect response distance method. See ref. [1]_.
+        The result of the defect response distance method [1]_
 
     References
     ----------
@@ -301,7 +301,7 @@ def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: U
 
 def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.ndarray, verbose: bool = True):
     r""" 
-    Finds the local pattern orientation using shapelet orientation at max response via an iterative scheme from ref. [1]_.
+    Computes the local pattern orientation[1]_ via an iterative scheme using shapelet orientation at maximum response from steerable filter theory[2]_.
 
     Parameters
     ----------
@@ -310,31 +310,32 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
     * l: float
         * The characteristic wavelength of the image
     * response: np.ndarray
-        * The 3D array corresponding to shapelet response from convresponse()
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
     * orients: np.ndarray
-        * The 3D array corresponding to the orientation at max response, obtained from convresponse()
+        * The optimal shapelet filter orientation at maximum response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
     * verbose: bool, optional
-        * True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
+        * True (default) to print out results of orientation algorithm to console
 
     Returns
     -------
     * mask: np.ndarray
-        * The mask for well-defined features. See ref. [1]_
+        * The mask for well-defined features
     * dilate: np.ndarray
-        * The dilated mask. See ref. [1]_
+        * The dilated mask
     * orientation: np.ndarray
-        * Applying smoothing/blending to the dilated mask via median filter kernel [2]_. See ref. [1]_
+        * Applying smoothing/blending to the dilated mask via median filter kernel[3]_
     * maxval: float
-        * The maximum allowed orientation value, where $maxval = 2*np.pi / m$
+        * The maximum allowed orientation value, where $maxval = \frac{2 \pi}{m}$
     
     Notes
     -----
-    This function uses ``shapelets.self_assembly.misc.trim_image`` during iteration to converge on an acceptable orientation result. 
+    This function uses ``shapelets.self_assembly.misc.trim_image`` during iteration to converge on an acceptable orientation result. Therefore, the orientation result will **not** have the same shape as the original image.
 
     References
     ----------
     .. [1] TODO: REFTINO
-    .. [2] https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.median_filter.html
+    .. [2] https://doi.org/10.1109/34.93808
+    .. [3] https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.median_filter.html
     
     """
     if (not isinstance(response, np.ndarray)) or (not isinstance(orients, np.ndarray)):
@@ -395,27 +396,27 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
 
 def rdistance(image: np.ndarray, response: np.ndarray, num_clusters: Union[str,int], ux: Union[str,list] = 'default', uy: Union[str,list] = 'default', verbose: bool = True):
     r""" 
-    Compute the response distance method from ref. [1]_ using the methodology described in ref. [2]_.
+    Compute the response distance method from ref.[1]_ using the methodology from ref.[2]_.
 
     Parameters
     ----------
     * image: numpy.ndarray
         * The image loaded as a numpy array
     * response: np.ndarray
-        * The 3D array corresponding to shapelet response from convresponse()
-    * num_clusters: str or int
-        * The number of clusters as input to k-means clustering [3]_. If str, acceptable value is "default" (which uses 20)
-    * ux: str or list
-        * The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime
-    * uy: str or list
-        * The bounds in the y-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime
+        * The magnitude of (maximum) convolutional response as a 3D array, obtained from ``shapelets.self_assembly.quant.convresponse``
+    * num_clusters: Union[str,int]
+        * The number of clusters as input to k-means clustering [3]_. If str, acceptable value is "default" (which uses 20 clusters[2]_)
+    * ux: Union[str,list]
+        * The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region during runtime
+    * uy: Union[str,list]
+        * The bounds in the y-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region during runtime
     * verbose: bool, optional
-        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console
+        True (default) to print out results of response distance method to console
 
     Returns
     -------
     * d: np.ndarray
-        * The response distance scalar field.
+        * The response distance scalar field. Its dimensions are the same as the input image
 
     References
     ----------

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -37,9 +37,7 @@ __all__ = [
 
 def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = 'default', normresponse: str = 'Vector', verbose: bool = True):
     r""" 
-    This function computes the convolution between a range of 
-    shapelets kernels and an image, extracting the magnitude of response
-    as well as the shapelet-based orientation.
+    This function computes the convolution between a range of shapelets kernels and an image, extracting the magnitude of response as well as the shapelet-based orientation.
     
     Parameters
     ----------
@@ -48,14 +46,11 @@ def convresponse(image: np.ndarray, l: float, shapelet_order: Union[str,int] = '
     l : float
         The characteristic wavelength of the image.
     shapelet_order : str or int
-        'default' to use higher-order shapelets (m<=m') as in ref [3].
-        Can also accept integer value to use shapelets for m = [1, shapelet_order].
+        'default' to use higher-order shapelets (m<=m') as in ref [3]. Can also accept integer value to use shapelets for m = [1, shapelet_order].
     normresponse : str, optional
-        Normalize magnitude of response (omega) in terms of response vectors = "Vector". Default. 
-        Normalize each m-fold response wrt itself on [0, 1) = "Individual".
+        Normalize magnitude of response (omega) in terms of response vectors = "Vector". Default. Normalize each m-fold response wrt itself on [0, 1) = "Individual".
     verbose: bool
-        True (default) to print out results of orientation algorithm to console.
-        False to not print any results or information to console.
+        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
 
     Returns
     -------
@@ -205,19 +200,14 @@ def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: U
     pattern_order : str
         Pattern order. Options are: 'stripe', 'square', 'hexagonal'.
     num_clusters : int or str
-        The number of clusters as input to k-means clustering [4].
-        Can use "default" to get default value based on pattern_order.
-        For stripe, square, and hexagonal patterns, the minimum value is 
-            4, 8, and 10 respectively. 
+        The number of clusters as input to k-means clustering [4]. Can use "default" to get default value based on pattern_order. For stripe, square, and hexagonal patterns, the minimum value is 4, 8, and 10 respectively. 
     
     Returns
     -------
     centroids : np.ndarray
-        The centroids from k-means clustering [2].
-        Each centroid is a row vector.
+        The centroids from k-means clustering [2]. Each centroid is a row vector.
     clusterMembers2D : np.ndarray
-        Shows which cluster each pixel from image is a member of.
-        I.e., value of 1 would mean it belongs to the cluster with centroid as centroids[1].
+        Shows which cluster each pixel from image is a member of. I.e., value of 1 would mean it belongs to the cluster with centroid as centroids[1].
     defects : np.ndarray
         The result of the defect response distance method. See [1]. 
 
@@ -311,8 +301,7 @@ def defectid(response: np.ndarray, l: float, pattern_order: str, num_clusters: U
 
 def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.ndarray, verbose: bool = True):
     r""" 
-    Finds the local pattern orientation using shapelet 
-    orientation at max response via an iterative scheme from [1].
+    Finds the local pattern orientation using shapelet orientation at max response via an iterative scheme from [1].
 
     Parameters
     ----------
@@ -323,11 +312,9 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
     response : np.ndarray
         The 3D array corresponding to shapelet response from convresponse().
     orients : np.ndarray
-        The 3D array corresponding to the orientation at max response,
-        obtained from convresponse().
+        The 3D array corresponding to the orientation at max response, obtained from convresponse().
     verbose: bool
-        True (default) to print out results of orientation algorithm to console.
-        False to not print any results or information to console.
+        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
 
     Returns
     -------
@@ -339,6 +326,10 @@ def orientation(pattern_order: str, l: float, response: np.ndarray, orients: np.
         Applying smoothing/blending to the dilated mask via median filter kernel [2]. See [1].
     maxval : float
         The maximum allowed orientation value, where maxval = 2*np.pi / (m)
+    
+    Notes
+    -----
+    This function uses shapelets.self_assembly.misc.trim_image during iteration to converge on an acceptable orientation result. 
 
     References
     ----------
@@ -413,19 +404,13 @@ def rdistance(image: np.ndarray, response: np.ndarray, num_clusters: Union[str,i
     response : np.ndarray
         The 3D array corresponding to shapelet response from convresponse().
     num_clusters : str or int
-        The number of clusters as input to k-means clustering [3].
-        If str, acceptable value is "default" (which uses 20).
+        The number of clusters as input to k-means clustering [3]. If str, acceptable value is "default" (which uses 20).
     ux : str or list
-        The bounds in the x-direction for the reference region.
-        If using list option, must be 2 element list.
-        Choosing "default" will force user to choose ref. region at runtime.
+        The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime.
     uy : str or list
-        The bounds in the y-direction for the reference region.
-        If using list option, must be 2 element list.
-        Choosing "default" will force user to choose ref. region at runtime.
+        The bounds in the y-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region at runtime.
     verbose: bool
-        True (default) to print out results of orientation algorithm to console.
-        False to not print any results or information to console.
+        True (default) to print out results of orientation algorithm to console. False to not print any results or information to console.
 
     Returns
     -------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -26,8 +26,7 @@ __all__ = [
 
 def lambda_to_beta(m: int, l: float):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the pattern [1, 2]
-    to the appropriate beta value for orthonormal polar shapelets from [3].
+    Converts lambda (l), the characteristic wavelength of the pattern [1, 2] to the appropriate beta value for orthonormal polar shapelets from [3].
     
     Parameters
     ----------
@@ -66,18 +65,14 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
     r""" 
     Find characteristic wavelength of an image from [1, 2].
 
-    matthew@matthew: The rng needs to be optimized better. 
-    For example, if the wavelength is bigger than 50 need to fix this.
-    But, if we just let rng = None (i.e., all wavelengths) then it will
-    find way too big of a wavelength as the scale...
+    matthew@matthew: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
     
     Parameters
     ----------
     image : np.ndarray
         The image to be processed.
     rng : list
-        Range of wavelengths to consider for maximum wavelength.
-        I.e., will return max wavelength in range of [0, 50] (default). 
+        Range of wavelengths to consider for maximum wavelength. I.e., will return max wavelength in range of [0, 50] (default). 
 
     Returns
     -------
@@ -129,8 +124,7 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
 
 def radialavg(image: np.ndarray):
     r""" 
-    Calculates the radially averaged intensity of an image. 
-    Based on work from [1, 2].
+    Calculates the radially averaged intensity of an image. Based on work from [1, 2].
     
     Parameters
     ----------
@@ -140,8 +134,7 @@ def radialavg(image: np.ndarray):
     Returns
     -------
     rai : np.ndarray
-        A 1d array with one intensity per integer radius, excluding 0.
-        eg. For image with radii [0, 1, 2, 3], len(rai) = 3.
+        A 1d array with one intensity per integer radius, excluding 0. eg. For image with radii [0, 1, 2, 3], len(rai) = 3.
 
     References
     ----------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -26,19 +26,19 @@ __all__ = [
 
 def lambda_to_beta(m: int, l: float):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the pattern [1, 2] to the appropriate beta value for orthonormal polar shapelets from [3].
+    Converts lambda (l), the characteristic wavelength of the pattern [1]_ [2]_ to the appropriate beta value for orthonormal polar shapelets from ref. [3]_.
     
     Parameters
     ----------
-    m : int
-        Shapelet degree of rotational symmetry.
-    l : float
-        The characteristic wavelength of the pattern from [1, 2].
+    * m: int
+        * Shapelet degree of rotational symmetry
+    * l: float
+        * The characteristic wavelength of the pattern
     
     Returns
     -------
-    beta : float
-        The characteristic shapelet length scale parameter based on [3].
+    * beta: float
+        * The characteristic shapelet length scale parameter based on ref. [3]_
 
     References
     ----------
@@ -63,21 +63,21 @@ def lambda_to_beta(m: int, l: float):
 
 def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True):
     r""" 
-    Find characteristic wavelength of an image from [1, 2].
+    Find characteristic wavelength of an image. Computed from refs [1]_ [2]_.
 
-    matthew@matthew: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
+    mpt@mpt: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
     
     Parameters
     ----------
-    image : np.ndarray
-        The image to be processed.
-    rng : list
-        Range of wavelengths to consider for maximum wavelength. I.e., will return max wavelength in range of [0, 50] (default). 
+    * image: np.ndarray
+        * The image to be processed
+    * rng: list
+        * Range of wavelengths to consider for maximum wavelength. I.e., will return max wavelength in range of [0, 50] (default)
 
     Returns
     -------
-    l : float or list
-        The characteristic wavelength of the image.
+    * char_wavelength: float
+        * The characteristic wavelength of the image
 
     References
     ----------
@@ -124,17 +124,17 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
 
 def radialavg(image: np.ndarray):
     r""" 
-    Calculates the radially averaged intensity of an image. Based on work from [1, 2].
+    Calculates the radially averaged intensity of an image. Based on work from [1]_ [2]_.
     
     Parameters
     ----------
-    image : np.ndarray
-        The image to be radially averaged.
+    * image: np.ndarray
+        * The image to be radially averaged
     
     Returns
     -------
-    rai : np.ndarray
-        A 1d array with one intensity per integer radius, excluding 0. eg. For image with radii [0, 1, 2, 3], len(rai) = 3.
+    * rai: np.ndarray
+        * A 1d array with one intensity per integer radius, excluding 0. eg. For image with radii [0, 1, 2, 3], len(rai) = 3
 
     References
     ----------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -26,19 +26,19 @@ __all__ = [
 
 def lambda_to_beta(m: int, l: float):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the pattern [1]_ [2]_ to the appropriate beta value for orthonormal polar shapelets from ref. [3]_.
+    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[3]_ (see ``shapelets.functions.orthonormalpolar2D``).
     
     Parameters
     ----------
     * m: int
         * Shapelet degree of rotational symmetry
     * l: float
-        * The characteristic wavelength of the pattern
+        * The characteristic wavelength of the image[1]_
     
     Returns
     -------
     * beta: float
-        * The characteristic shapelet length scale parameter based on ref. [3]_
+        * The characteristic shapelet length scale parameter based on ref.[3]_
 
     References
     ----------
@@ -63,7 +63,7 @@ def lambda_to_beta(m: int, l: float):
 
 def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True):
     r""" 
-    Find characteristic wavelength of an image. Computed from refs [1]_ [2]_.
+    Find characteristic wavelength of an image. Computed from refs[1,2]_.
 
     mpt@mpt: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
     
@@ -124,7 +124,7 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
 
 def radialavg(image: np.ndarray):
     r""" 
-    Calculates the radially averaged intensity of an image. Based on work from [1]_ [2]_.
+    Calculates the radially averaged intensity of an image. Based on work from[1,2]_.
     
     Parameters
     ----------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -26,7 +26,7 @@ __all__ = [
 
 def lambda_to_beta(m: int, l: float):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[3]_ (see ``shapelets.functions.orthonormalpolar2D``).
+    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ (see shapelets.functions.orthonormalpolar2D).
     
     Parameters
     ----------
@@ -38,13 +38,12 @@ def lambda_to_beta(m: int, l: float):
     Returns
     -------
     * beta: float
-        * The characteristic shapelet length scale parameter based on ref.[3]_
+        * The characteristic shapelet length scale parameter based on ref.[2]_
 
     References
     ----------
     .. [1] http://dx.doi.org/10.1103/PhysRevE.91.033307
-    .. [2] http://hdl.handle.net/10012/8922
-    .. [3] https://doi.org/10.1088/1361-6528/aaf353
+    .. [2] https://doi.org/10.1088/1361-6528/aaf353
 
     """
     if m == 4:   
@@ -63,7 +62,7 @@ def lambda_to_beta(m: int, l: float):
 
 def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True):
     r""" 
-    Find characteristic wavelength of an image. Computed from refs[1,2]_.
+    Find characteristic wavelength of an image. Computed from ref.[1]_.
 
     mpt@mpt: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
     
@@ -82,7 +81,6 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
     References
     ----------
     .. [1] http://dx.doi.org/10.1103/PhysRevE.91.033307
-    .. [2] http://hdl.handle.net/10012/8922
     
     """
     if type(image) != np.ndarray:
@@ -124,7 +122,7 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
 
 def radialavg(image: np.ndarray):
     r""" 
-    Calculates the radially averaged intensity of an image. Based on work from[1,2]_.
+    Calculates the radially averaged intensity of an image. Based on work from ref.[1]_.
     
     Parameters
     ----------
@@ -139,7 +137,6 @@ def radialavg(image: np.ndarray):
     References
     ----------
     .. [1] http://dx.doi.org/10.1103/PhysRevE.91.033307
-    .. [2] http://hdl.handle.net/10012/8922
     
     """
     # Determine two arrays, x and y, which contain the indices of the image.


### PR DESCRIPTION
* Removed unnecessary carriage returns in all package documentation and docstrings
* Modified github workflow to render latex math on repo website
* Converted all function docstrings from .rst (reStructuredText) to .md (markdown)