### PR TITLE
Improved read_image function and corrected path handling

### DIFF
--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -17,6 +17,7 @@
 
 ## Section 1: importing modules
 import os 
+from pathlib import Path
 
 from shapelets.self_assembly import (
     convresponse,
@@ -36,10 +37,11 @@ uy = [150, 180]
 ## Section 3: code
 
 # 3.1: image and output directory handling
-image_path = os.getcwd()+'/images/'
+image_path = os.path.join(Path(__file__).parents[0], 'images')
 image = read_image(image_name = image_name, image_path = image_path)
-save_path = os.getcwd()+'/output/'
-if not os.path.exists(save_path): os.mkdir("output")
+save_path = os.path.join(Path(__file__).parents[0], 'output')
+if not os.path.exists(save_path): 
+    os.mkdir(save_path)
 
 # 3.2: get the characteristic wavelength of the pattern
 char_wavelength = get_wavelength(image = image)

--- a/examples/example_2/example_2.py
+++ b/examples/example_2/example_2.py
@@ -17,6 +17,7 @@
 
 ## Section 1: importing modules
 import os 
+from pathlib import Path
 
 from shapelets.self_assembly import (
     convresponse,
@@ -34,10 +35,11 @@ num_clusters = 10
 ## Section 3: code
 
 # 3.1: image and output directory handling
-image_path = os.getcwd()+'/images/'
+image_path = os.path.join(Path(__file__).parents[0], 'images')
 image = read_image(image_name = image_name, image_path = image_path)
-save_path = os.getcwd()+'/output/'
-if not os.path.exists(save_path): os.mkdir("output")
+save_path = os.path.join(Path(__file__).parents[0], 'output')
+if not os.path.exists(save_path): 
+    os.mkdir(save_path)
 
 # 3.2: get the characteristic wavelength of the pattern
 char_wavelength = get_wavelength(image = image)

--- a/examples/example_3/example_3.py
+++ b/examples/example_3/example_3.py
@@ -17,6 +17,7 @@
 
 ## Section 1: importing modules
 import os 
+from pathlib import Path
 
 from shapelets.self_assembly import (
     convresponse,
@@ -33,10 +34,11 @@ pattern_order = "square"
 ## Section 3: code
 
 # 3.1: image and output directory handling
-image_path = os.getcwd()+'/images/'
+image_path = os.path.join(Path(__file__).parents[0], 'images')
 image = read_image(image_name = image_name, image_path = image_path)
-save_path = os.getcwd()+'/output/'
-if not os.path.exists(save_path): os.mkdir("output")
+save_path = os.path.join(Path(__file__).parents[0], 'output')
+if not os.path.exists(save_path): 
+    os.mkdir(save_path)
 
 # 3.2: get the characteristic wavelength of the pattern
 char_wavelength = get_wavelength(image = image)

--- a/examples/example_4/example_4.py
+++ b/examples/example_4/example_4.py
@@ -16,8 +16,9 @@
 ########################################################################################################################
 
 ## Section 1: importing modules
-
 import os
+from pathlib import Path
+
 from shapelets.astronomy import (
     load_fits_data,
     get_postage_stamps,
@@ -32,9 +33,10 @@ compression_order = 20
 ## Section 3: code
 
 # 3.1: loading .fits data and output directory handling
-save_path = os.getcwd()+'/output/'
-if not os.path.exists(save_path): os.mkdir("output")
-fits_path = os.getcwd()+'/images/' + fits_name
+save_path = os.path.join(Path(__file__).parents[0], 'output')
+if not os.path.exists(save_path): 
+    os.mkdir(save_path)
+fits_path = os.path.join(Path(__file__).parents[0], 'images', fits_name) 
 
 output_base_path = save_path+fits_path[fits_path.rfind('/'):-5]
 fits_data = load_fits_data(fits_path)

--- a/shapelets/_entry_points.py
+++ b/shapelets/_entry_points.py
@@ -24,20 +24,22 @@ from . import _run
 
 def _run_shapelets():
     r"""
-    Main function that runs shapelets. This is only invoked via the entry point "shapelets CONFIG" where CONFIG is the name of the configuration plaintext file.      
+    Main function that runs shapelets. This is only invoked via the entry point "shapelets CONFIG" where CONFIG is the name of the configuration plaintext file in the same directory level as the entry point was called from.      
 
     """
-    # Arguments for command line use
-
-    if len(sys.argv) == 1: # if user did not provide any configuration path (which is required)
+    # if user did not provide any configuration filename (which is required)
+    if len(sys.argv) == 1: 
         raise RuntimeError('Please provide name of config file, i.e. "shapelets config".')
 
-    elif len(sys.argv) == 2: # if user did provide a configuration filename/path
+     # if user did provide a configuration filename/path
+    elif len(sys.argv) == 2:
         config_file = sys.argv[1]
-        _run._run(config_file)
+        working_dir = os.getcwd() 
+        _run._run(config_file, working_dir)
 
-    else: # if the user provides more than 1 argument (in addition to shapelets). Print error messages and quit.
-        raise RuntimeError('shapelets entry point only supports the config file name. I.e. "shapelets config".')
+    # if the user provides more than 1 argument (in addition to shapelets). Print error messages and quit.
+    else: 
+        raise RuntimeError('shapelets entry point only supports the config file name in addition to the module. I.e. "shapelets config".')
 
 def _run_tests():
     r"""

--- a/shapelets/_run.py
+++ b/shapelets/_run.py
@@ -18,6 +18,7 @@
 import ast
 import configparser
 import os
+from pathlib import Path
 
 from .astronomy.galaxy import *
 
@@ -25,14 +26,16 @@ from .self_assembly.misc import *
 from .self_assembly.quant import *
 from .self_assembly.wavelength import *
 
-def _run(config_file: str) -> None:
+def _run(config_file: str, working_dir: str) -> None:
     r"""
     Main run function that handles input configuration file.
     
     Parameters
     ----------
     * config_file : str
-        * The name of the configuration file
+        * The name of the configuration file in working_dir
+    * working_dir : str
+        * The absolute path (working directory) where the entry point was invoked from
     
     Notes
     -----
@@ -43,18 +46,22 @@ def _run(config_file: str) -> None:
 
     # instantiate and read
     config = configparser.ConfigParser()
-    config.read(config_file)
+    config_file = os.path.join(working_dir, config_file)
+    if not os.path.exists(config_file):
+        raise RuntimeError(f"Configuration file {config_file} does not exist. Check config filename spelling and ensure that it is located in {working_dir}.")
+    else:
+        config.read(config_file)
 
     # handle method
     method = config.get('general', 'method')
 
     # image and output paths
-    image_path = os.getcwd()+'/images/'
-    save_path = os.getcwd()+'/output/'
+    image_path = os.path.join(working_dir, 'images')
+    save_path = os.path.join(working_dir, 'output')
     if not os.path.exists(image_path): 
         raise RuntimeError(f"Path '{image_path}' does not exist.")
     if not os.path.exists(save_path): 
-        os.mkdir("output")
+        os.mkdir(save_path)
 
     ## self_assembly submodule use ##
         
@@ -112,7 +119,7 @@ def _run(config_file: str) -> None:
         
     # retrieving .fits path (if .fits file is provided)
     elif config.get('general', 'fits_name', fallback=None):
-        fits_path = os.getcwd()+'/images/' + config.get('general', 'fits_name')
+        fits_path = os.path.join(working_dir, 'images', config.get('general', 'fits_name'))
 
         if method == 'galaxy_decompose':
             shapelet_order = config.get('galaxy_decompose', 'shapelet_order', fallback = 'default')


### PR DESCRIPTION
Significantly improved capabilities of read_image function in misc.py, including:
* a check to ensure the image exists in the path provided,
* detection of very large images and automatic rescaling to smaller dimensions (very large images used to kill k-means clustering process)
* also changed the trim_image function to only trim half of the characteristic wavelength, not a full length 

Also modified the relative path handling:
* in the example .py files which can now be run from any directory (previously would break if executed from any dir other than where example.py is stored), and
* to ensure that working directory contains the configuration filename given when the main entry point (i.e. `shapelets config`) is invoked, now producing a Runtime error with adequate message 