### PR TITLE
Reduced inputs needed for self-assembly methods and improved readability

### DIFF
--- a/examples/example_1/config
+++ b/examples/example_1/config
@@ -4,6 +4,6 @@ method = response_distance
 
 [response_distance]
 shapelet_order = default
-num_clusters = 20
+num_clusters = default
 ux = [50, 80]
 uy = [150, 180]

--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -20,17 +20,15 @@ import os
 from pathlib import Path
 
 from shapelets.self_assembly import (
-    convresponse,
     read_image,
     rdistance,
-    get_wavelength,
     process_output
 ) 
 
 ## Section 2: parameters
 image_name = "lamSIM1.png"
-shapelet_order = 'default' 
-num_clusters = 20
+shapelet_order = 'default' # can also be integer value to set upper bound
+num_clusters = 'default' # default is 20, can be any other positive integer 
 ux = [50, 80]
 uy = [150, 180]
 
@@ -43,17 +41,11 @@ save_path = os.path.join(Path(__file__).parents[0], 'output')
 if not os.path.exists(save_path): 
     os.mkdir(save_path)
 
-# 3.2: get the characteristic wavelength of the pattern
-char_wavelength = get_wavelength(image = image)
-
-# 3.3: get the convolutional response 
-response = convresponse(image = image, l = char_wavelength, shapelet_order = shapelet_order, normresponse = 'Vector')[0]
-
-# 3.4: compute the response distance 
-try:
-    rd_field = rdistance(image = image, response = response, num_clusters = num_clusters, ux = ux, uy = uy)
+# 3.2: compute the response distance 
+try: # if ux, uy are defined above
+    rd_field = rdistance(image = image, num_clusters = num_clusters, shapelet_order = shapelet_order, ux = ux, uy = uy)
 except NameError:
-    rd_field = rdistance(image = image, response = response, num_clusters = num_clusters, ux = 'default', uy = 'default')
+    rd_field = rdistance(image = image, num_clusters = num_clusters, shapelet_order = shapelet_order, ux = 'default', uy = 'default')
 
-# processing and saving the results to the **output/** directory 
+# 3.3: processing and saving the results to the **output/** directory 
 process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)

--- a/examples/example_2/config
+++ b/examples/example_2/config
@@ -4,4 +4,3 @@ method = identify_defects
 
 [identify_defects]
 pattern_order = hexagonal
-num_clusters = 10

--- a/examples/example_2/example_2.py
+++ b/examples/example_2/example_2.py
@@ -20,17 +20,14 @@ import os
 from pathlib import Path
 
 from shapelets.self_assembly import (
-    convresponse,
     read_image,
     defectid,
-    get_wavelength,
     process_output
 ) 
 
 ## Section 2: parameters
 image_name = "hexSIM1.png"
 pattern_order = "hexagonal"
-num_clusters = 10
 
 ## Section 3: code
 
@@ -41,17 +38,8 @@ save_path = os.path.join(Path(__file__).parents[0], 'output')
 if not os.path.exists(save_path): 
     os.mkdir(save_path)
 
-# 3.2: get the characteristic wavelength of the pattern
-char_wavelength = get_wavelength(image = image)
+# 3.2: compute the defect identification method
+centroids, clusterMembers, defects = defectid(image = image, pattern_order = pattern_order)
 
-# 3.3: get the convolutional response 
-response = convresponse(image = image, l = char_wavelength, shapelet_order = 'default', normresponse = 'Vector')[0]
-
-# 3.4: compute the defect identification method
-try:
-    centroids, clusterMembers, defects = defectid(response = response, l = char_wavelength, pattern_order = pattern_order, num_clusters = num_clusters)
-except NameError:
-    centroids, clusterMembers, defects = defectid(response = response, l = char_wavelength, pattern_order = pattern_order, num_clusters = 'default')
-
-# processing and saving the results to the **output/** directory 
+# 3.3: processing and saving the results to the **output/** directory 
 process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)

--- a/examples/example_3/example_3.py
+++ b/examples/example_3/example_3.py
@@ -20,10 +20,8 @@ import os
 from pathlib import Path
 
 from shapelets.self_assembly import (
-    convresponse,
     read_image,
     orientation,
-    get_wavelength,
     process_output
 ) 
 
@@ -40,14 +38,8 @@ save_path = os.path.join(Path(__file__).parents[0], 'output')
 if not os.path.exists(save_path): 
     os.mkdir(save_path)
 
-# 3.2: get the characteristic wavelength of the pattern
-char_wavelength = get_wavelength(image = image)
+# 3.2: compute the local pattern orientation
+mask, dilate, blended, maxval = orientation(image = image, pattern_order = pattern_order)
 
-# 3.3: get the convolutional response 
-response, orients = convresponse(image = image, l = char_wavelength, shapelet_order = 6, normresponse = 'Individual')
-
-# 3.4: compute the local pattern orientation
-mask, dilate, blended, maxval = orientation(pattern_order = pattern_order, l = char_wavelength, response = response, orients = orients)
-
-# processing and saving the results to the **output/** directory 
+# 3.3: processing and saving the results to the **output/** directory 
 process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)

--- a/shapelets/_run.py
+++ b/shapelets/_run.py
@@ -72,9 +72,6 @@ def _run(config_file: str, working_dir: str) -> None:
         image_name = config.get('general', 'image_name')
         image = read_image(image_name = image_name, image_path = image_path)
 
-        # obtain characteristic wavelength, needed for all self-assembly applications
-        char_wavelength = get_wavelength(image = image)
-
         if method == 'response_distance':
             shapelet_order = config.get('response_distance', 'shapelet_order', fallback = 'default')
             if shapelet_order != 'default':
@@ -96,7 +93,7 @@ def _run(config_file: str, working_dir: str) -> None:
 
         elif method == 'orientation':
             pattern_order = config.get('orientation', 'pattern_order')
-
+            char_wavelength = get_wavelength(image = image)
             response, orients = convresponse(image = image, l = char_wavelength, shapelet_order = 6, normresponse = 'Individual')
             mask, dilate, blended, maxval = orientation(pattern_order = pattern_order, l = char_wavelength, response = response, orients = orients)
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)
@@ -104,13 +101,7 @@ def _run(config_file: str, working_dir: str) -> None:
         elif method == 'identify_defects':
             pattern_order = config.get('identify_defects', 'pattern_order')
 
-            num_clusters = config.get('identify_defects', 'num_clusters', fallback = 'default') 
-            if num_clusters != 'default':
-                num_clusters = ast.literal_eval(num_clusters)
-
-            response = convresponse(image = image, l = char_wavelength, shapelet_order = 'default', normresponse = 'Vector')[0]
-            centroids, clusterMembers, defects = defectid(response = response, l = char_wavelength,
-                                                          pattern_order = pattern_order, num_clusters = num_clusters)
+            centroids, clusterMembers, defects = defectid(image = image, pattern_order = pattern_order)
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)
         
         else:

--- a/shapelets/_run.py
+++ b/shapelets/_run.py
@@ -67,6 +67,8 @@ def _run(config_file: str, working_dir: str) -> None:
         
     # parsing input image of nanostructure
     if config.get('general', 'image_name', fallback=None):
+
+        # read image to be analyzed
         image_name = config.get('general', 'image_name')
         image = read_image(image_name = image_name, image_path = image_path)
 
@@ -89,8 +91,7 @@ def _run(config_file: str, working_dir: str) -> None:
             if uy != 'default':
                 uy = ast.literal_eval(uy)
 
-            response = convresponse(image = image, l = char_wavelength, shapelet_order = shapelet_order, normresponse = 'Vector')[0]
-            rd_field = rdistance(image = image, response = response, num_clusters = num_clusters, ux = ux, uy = uy)
+            rd_field = rdistance(image = image, num_clusters = num_clusters, shapelet_order = shapelet_order, ux = ux, uy = uy)
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)
 
         elif method == 'orientation':

--- a/shapelets/_run.py
+++ b/shapelets/_run.py
@@ -89,21 +89,23 @@ def _run(config_file: str, working_dir: str) -> None:
                 uy = ast.literal_eval(uy)
 
             rd_field = rdistance(image = image, num_clusters = num_clusters, shapelet_order = shapelet_order, ux = ux, uy = uy)
+
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'response_distance', d = rd_field, num_clusters = num_clusters)
 
         elif method == 'orientation':
             pattern_order = config.get('orientation', 'pattern_order')
-            char_wavelength = get_wavelength(image = image)
-            response, orients = convresponse(image = image, l = char_wavelength, shapelet_order = 6, normresponse = 'Individual')
-            mask, dilate, blended, maxval = orientation(pattern_order = pattern_order, l = char_wavelength, response = response, orients = orients)
+
+            mask, dilate, blended, maxval = orientation(image = image, pattern_order = pattern_order)
+
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'orientation', mask = mask, dilate = dilate, orientation = blended, maxval = maxval)
-    
+            
         elif method == 'identify_defects':
             pattern_order = config.get('identify_defects', 'pattern_order')
 
             centroids, clusterMembers, defects = defectid(image = image, pattern_order = pattern_order)
+
             process_output(image = image, image_name = image_name, save_path = save_path, output_from = 'identify_defects', centroids = centroids, clusterMembers = clusterMembers, defects = defects)
-        
+
         else:
             raise ValueError('"method" parameter from configuration file not recognized by shapelets.')
 
@@ -124,7 +126,6 @@ def _run(config_file: str, working_dir: str) -> None:
             fits_data = load_fits_data(fits_path)
             (galaxy_stamps, star_stamps, noiseless_data) = get_postage_stamps(fits_data, output_base_path)
             decompose_galaxies(galaxy_stamps, star_stamps, noiseless_data, n_max, compression_factor, output_base_path)
-
         else:
             raise ValueError('"method" parameter from configuration file not recognized by shapelets.')
         

--- a/shapelets/docs/example_1.py
+++ b/shapelets/docs/example_1.py
@@ -55,33 +55,33 @@ The configuration file provided in the example [directory](https://github.com/uw
 
 	[response_distance]
 	shapelet_order = default
-	num_clusters = 20
+	num_clusters = default
 	ux = [50, 80]
 	uy = [150, 180]
 
 where **image_name** and **method** are required parameters that specify the image filename and method used for analysis.
 
-The method outlined in the configuration file will also have its own header with specific parameters. The **response_distance** method may contain up to four parameters. Note that *default* refers to the default value if the parameter is excluded from the configuration file.
+The method outlined in the configuration file will also have its own header with specific parameters. The **response_distance** method may contain up to four parameters. Only values that have a default value may be omitted from the configuration file (see below, if no default value is written then it must be present in configuration file).
 
 **shapelet_order** `int`
 
 * The maximum shapelet order ($m'$) used for convolution operations, i.e. $m \in [1, m']$ shapelets are used 
-* default = $m'$ $\rightarrow$ computed by the higher-order shapelet algorithm ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
+* Default value is computed by the higher-order shapelet algorithm ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
 
 **num_clusters** `int`
 
 * The number of clusters for k-means clustering. Note using 0 is acceptable and will use all response vectors in the reference region (subdomain) ([R. Suderman (2015)](https://doi.org/10.1103/PhysRevE.91.033307))
-* default = 20 $\rightarrow$ as determined by a distortion analysis ([T. Akdeniz (2018)](https://doi.org/10.1088/1361-6528/aaf353))
+* Default value is 20 clusters as determined by a distortion analysis ([T. Akdeniz (2018)](https://doi.org/10.1088/1361-6528/aaf353))
 
 **ux** `list`
 
 * The lower and upper x-coordinates (respectively) of the reference region (subdomain)
-* default $\rightarrow$ user is required to select x-bounds during runtime, see [here](#selecting-subdomain-bounds-during-runtime) for instructions
+* Default requires user to select x-bounds during runtime, see [here](#selecting-subdomain-bounds-during-runtime) for instructions
 
 **uy** `list`
 
 * The lower and upper y-coordinates (respectively) of the reference region (subdomain)
-* default $\rightarrow$ user is required to select y-bounds during runtime, see [here](#selecting-subdomain-bounds-during-runtime) for instructions
+* Default requires user to select y-bounds during runtime, see [here](#selecting-subdomain-bounds-during-runtime) for instructions
 
 ### Run Example
 

--- a/shapelets/docs/example_2.py
+++ b/shapelets/docs/example_2.py
@@ -57,25 +57,14 @@ The configuration file provided in the example [directory](https://github.com/uw
 
 	[identify_defects]
 	pattern_order = hexagonal
-	num_clusters = 10
 
 where **image_name** and **method** are required parameters that specify the image filename and method used for analysis.
 
-The method outlined in the configuration file will also have its own header with specific parameters. The **identify_defects** method may contain up to two parameters. Note that default refers to the default value if the parameter is excluded from the configuration file.
+The method outlined in the configuration file will also have its own header with specific parameters. The **identify_defects** method may contain up to two parameters. Only values that have a default value may be omitted from the configuration file (see below, if no default value is written then it must be present in configuration file). 
 
 **pattern_order** `str`
 
 * The pattern order (symmetry) observed in the image. Options are `stripe`, `square`, `hexagonal`
-* This parameter **does not have a default value**
-
-**num_clusters** `int`
-
-* The number of clusters for k-means clustering. Must be $\geq$ 1.
-* Default values are as follows,
-	* If pattern_order = stripe $\rightarrow$ 4
-	* If pattern_order = square $\rightarrow$ 8
-	* If pattern_order = hexagonal $\rightarrow$ 10
-* If an integer value is provided that is below the above default, the code will defer to the default value
 
 ### Run Example
 

--- a/shapelets/docs/example_3.py
+++ b/shapelets/docs/example_3.py
@@ -60,12 +60,11 @@ The configuration file provided in the example [directory](https://github.com/uw
 
 where **image_name** and **method** are required parameters that specify the image filename and method used for analysis.
 
-The method outlined in the configuration file will also have its own header with specific parameters. The orientation method must contain one parameter. Note that default refers to the default value if the parameter is excluded from the configuration file.
+The method outlined in the configuration file will also have its own header with specific parameters. The orientation method must contain one parameter.  Only values that have a default value may be omitted from the configuration file (see below, if no default value is written then it must be present in configuration file). 
 
 **pattern_order** `str`
 
 * The pattern order (symmetry) observed in the image. Options are `stripe`, `square`, `hexagonal`
-* This parameter does not have a default value
 
 ## Run Example
 

--- a/shapelets/docs/example_4.py
+++ b/shapelets/docs/example_4.py
@@ -70,17 +70,17 @@ The configuration file provided in the example [directory](https://github.com/uw
 
 where **image_name** and **method** are required parameters that specify the image filename and method used for analysis.
 
-The method outlined in the configuration file will also have its own header with specific parameters. The **galaxy_decompose** method may contain up to two parameters. Note that default refers to the default value if the parameter is excluded from the configuration file.
+The method outlined in the configuration file will also have its own header with specific parameters. The **galaxy_decompose** method may contain up to two parameters.  Only values that have a default value may be omitted from the configuration file (see below, if no default value is written then it must be present in configuration file). 
 
 **shapelet_order** `int`
 
 * The maximum shapelet order (i.e. cartesian shapelets ([A. Refregier (2003)](https://doi.org/10.1046/j.1365-8711.2003.05901.x))) to calculate coefficients such that $n_1 + n_2 \leq n_{max}$.
-* default = 10
+* Default value is 10
 
 **compression_order** `int`
 
 * The number of shapelet coefficients to use for final image reconstruction
-* default = 25
+* Default value is 25. Here 20 is used just as an example
 
 ### Run Example
 

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -154,8 +154,13 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
     .. [1] http://dx.doi.org/10.1088/1361-6528/ad1df4
 
     """
+    # check that save_path exists
+    if not os.path.exists(save_path):
+        os.mkdir(save_path)
+        
     os.chdir(save_path)
 
+    # need to get characteristic wavelength for image trimming
     char_wavelength = get_wavelength(image = image, verbose = False)
 
     if output_from == 'response_distance':

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -162,6 +162,8 @@ def process_output(image: np.ndarray, image_name: str, save_path: str, output_fr
         # get kwargs
         d = kwargs['d']
         num_clusters = kwargs['num_clusters']
+        if num_clusters == 'default':
+            num_clusters = '20'
 
         # final image processing for response distance scalar field
         d = (d-d.min()) / (d.max()-d.min())

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -225,7 +225,7 @@ def defectid(image: np.ndarray, pattern_order: str, verbose: bool = True):
     num_clusters = min_clusters[pattern_order]
     
     # get convolutional response data 
-    response = convresponse(image = image, shapelet_order = 'default', normresponse = 'Vector')[0]
+    response = convresponse(image = image, shapelet_order = 'default', normresponse = 'Vector', verbose=verbose)[0]
     response2D = response.reshape(-1, response.shape[-1])
     
     # clustering 
@@ -319,7 +319,7 @@ def orientation(image: np.ndarray, pattern_order: str, verbose: bool = True):
     l = get_wavelength(image=image, verbose=False)
 
     # get convolutional response data up to m=6 (higher-order shapelets not needed for this method)
-    response, orients = convresponse(image = image, shapelet_order = 6, normresponse = 'Individual')
+    response, orients = convresponse(image = image, shapelet_order = 6, normresponse = 'Individual', verbose=verbose)
 
     # find the response threshold iteratively 
     orient = orients[:,:,ind].copy()
@@ -455,7 +455,7 @@ def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shape
     
     # get convolutional response data 
     # shapelet_order parameter valid input check is enforced in the convresponse() function
-    response = convresponse(image = image, shapelet_order = shapelet_order, normresponse = 'Vector')[0]
+    response = convresponse(image = image, shapelet_order = shapelet_order, normresponse = 'Vector', verbose=verbose)[0]
 
     # compute response distance
     Ny, Nx = response.shape[0], response.shape[1]

--- a/tests/self_assembly/TestMethods.py
+++ b/tests/self_assembly/TestMethods.py
@@ -47,11 +47,7 @@ class TestMethods(unittest.TestCase):
         cls.image = read_image(image_name="hexSIM1.png", image_path=cls.dir, verbose=False)
         assert isinstance(cls.image, np.ndarray)
 
-        cls.wvl = get_wavelength(image = cls.image, verbose = False)
-        assert isinstance(cls.wvl, numbers.Real)
-
-        cls.omega, cls.phi = convresponse(cls.image, cls.wvl, shapelet_order='default', \
-                                          verbose=False)
+        cls.omega, cls.phi = convresponse(cls.image, shapelet_order='default', verbose=False)
     
     # This test will be run first on purpose
     def test_a_first(self) -> None:
@@ -63,54 +59,44 @@ class TestMethods(unittest.TestCase):
 
     def test_convresponse(self) -> None:
         with self.assertRaises(TypeError):
-            convresponse([], self.wvl, shapelet_order='default')
+            convresponse([], shapelet_order='default')
 
         with self.assertRaises(ValueError): 
-            convresponse(self.image, self.wvl, shapelet_order='')
+            convresponse(self.image, shapelet_order='')
         with self.assertRaises(TypeError):
-            convresponse(self.image, self.wvl, shapelet_order=5.)
+            convresponse(self.image, shapelet_order=5.)
         
         with self.assertRaises(TypeError):
-            convresponse(self.image, self.wvl, shapelet_order='default', \
-                         normresponse=[])
+            convresponse(self.image, shapelet_order='default', normresponse=[])
         with self.assertRaises(ValueError):
-            convresponse(self.image, self.wvl, shapelet_order='default', \
-                         normresponse='')
+            convresponse(self.image, shapelet_order='default', normresponse='')
 
         # Test non-default input of shapelet_order parameter 
-        omega, phi = convresponse(self.image, self.wvl, shapelet_order=20, verbose=False)
+        omega, phi = convresponse(self.image, shapelet_order=20, verbose=False)
         self.assertEqual(omega.shape, self.image.shape + (20,))
         self.assertEqual(phi.shape, self.image.shape + (20,))
     
     # Note: cannot test outputs as defectid() is an interactive function.
     def test_defectid(self) -> None:
         with self.assertRaises(TypeError):
-            defectid([], self.wvl, 'stripe', 'default')
+            defectid([], pattern_order='stripe')
         
         with self.assertRaises(ValueError):
-            defectid(self.omega, self.wvl, 'stripe', '')
+            defectid(self.image, pattern_order='')
         with self.assertRaises(TypeError):
-            defectid(self.omega, self.wvl, 'stripe', 5.)
-
-        with self.assertRaises(TypeError):
-            defectid(self.omega, self.wvl, [], 'default')
-        with self.assertRaises(ValueError):
-            defectid(self.omega, self.wvl, 'rectangular', 'default')
+            defectid(self.image, pattern_order=1.)
 
     def test_orientation(self) -> None:
         with self.assertRaises(TypeError):
-            orientation('hexagonal', self.wvl, [], self.phi)
-        with self.assertRaises(TypeError):
-            orientation('hexagonal', self.wvl, self.omega, [])
+            orientation([], pattern_order='square')
 
-        with self.assertRaises(TypeError):
-            orientation([], self.wvl, self.omega, self.phi)
         with self.assertRaises(ValueError):
-            orientation('rectangular', self.wvl, self.omega, self.phi)
+            orientation(self.image, pattern_order='')
+        with self.assertRaises(TypeError):
+            orientation(self.image, pattern_order=1.)
         
         print(' -> this test may take more than a few seconds')
-        mask, dilate, orient_result, _ = orientation('hexagonal', self.wvl, self.omega, \
-                                                     self.phi, verbose=False)
+        mask, dilate, orient_result, _ = orientation(self.image, pattern_order='hexagonal', verbose=False)
         
         self.assertTrue(isinstance(mask, np.ndarray))
         self.assertTrue(isinstance(dilate, np.ndarray))
@@ -122,29 +108,28 @@ class TestMethods(unittest.TestCase):
     
     def test_rdistance(self) -> None:
         with self.assertRaises(TypeError):
-            rdistance([], self.omega, 'default', 'default', 'default')
-
-        with self.assertRaises(TypeError):
-            rdistance(self.image, [], 'default', 'default', 'default')
+            rdistance([])
         
         with self.assertRaises(ValueError):
-            rdistance(self.image, self.omega, '', 'default', 'default')
+            rdistance(self.image, num_clusters='')
+        with self.assertRaises(TypeError):
+            rdistance(self.image, num_clusters=1.)
 
         with self.assertRaises(TypeError):
-            rdistance(self.image, self.omega, 'default', [1, 2], 'default')
+            rdistance(self.image, num_clusters='default', ux=[1, 2], uy='default')
         with self.assertRaises(ValueError):
-            rdistance(self.image, self.omega, 'default', 'incorrect', 'default')
+            rdistance(self.image, num_clusters='default', ux='incorrect', uy='default')
         with self.assertRaises(ValueError):
-            rdistance(self.image, self.omega, 'default', 'default', 'incorrect')            
+            rdistance(self.image, num_clusters='default', ux='default', uy='incorrect')            
         with self.assertRaises(ValueError):
-            rdistance(self.image, self.omega, 'default', [1,2,3], [1,2])
+            rdistance(self.image, num_clusters='default', ux=[1,2,3], uy=[1,2])
         with self.assertRaises(ValueError):
-            rdistance(self.image, self.omega, 'default', [1,2], [1,2,3])
+            rdistance(self.image, num_clusters='default', ux=[1,2], uy=[1,2,3])
 
         ux, uy = [237, 283], [32, 78]
         print(' -> this test may take more than a few seconds')
 
-        d = rdistance(self.image, self.omega, 'default', ux, uy, verbose=False)
+        d = rdistance(self.image, num_clusters='default', ux=ux, uy=uy, verbose=False)
 
         self.assertTrue(d.shape, self.image.shape)
         self.assertTrue(d.min() >= 0.)


### PR DESCRIPTION
Reduced number of parameters for self-assembly methods and improved readability, i.e.
*  Previously, calling a self-assembly main method from `shapelets.self_assembly.quant` (i.e. `rdistance`, `orientation`) required information from other functions first, which reduced the usability of these methods. This has been removed, granting these functions more independence from a user perspective

Other minor changes to support this change are in the example documentation and .py files, unit tests, and the _run() function which handles the configuration file method (main entry point handling).