### PR TITLE
Fixed test entry point bug that used wrong python version

### DIFF
--- a/shapelets/_entry_points.py
+++ b/shapelets/_entry_points.py
@@ -56,9 +56,18 @@ def _run_tests():
     tests_dir = os.path.join(Path(__file__).parents[0], 'tests')
     os.chdir(tests_dir)
 
-    # command line arguments based on user OS
     # automatically find all tests using unittest built-in discovery component
+    # run unit tests from command line
     if str(platform.system()) == 'Windows':
-        os.system('python -B -m unittest -v')
-    else:
-        os.system('python3 -B -m unittest -v')               
+        # force Python3, but specific version is difficult to automate
+        os.system('py -3 -B -m unittest -v')
+    
+    else: # MAC and Linux systems
+        # find specific python version based on installation path
+        split_path = os.getcwd().split('/')
+        py_version = [py for py in split_path if 'python' in py]
+        if not py_version: # empty = default installation path not used, resort to default
+            os.system('python3 -B -m unittest -v')
+        else:
+            # In the event of non-standard installation paths, take last entry in py_version
+            os.system(f'{py_version[-1]} -B -m unittest -v')               


### PR DESCRIPTION
This closes #46.

Windows
* Unit test entry point now forces use of locally installed python 3, as before it was non-specific such that python 2 could be used (and therefore would not work)

MAC / Linux
* Unit test entry point now looks for the pip installation path of shapelets package, and grabs the correct python version from this path.
* In the event no python version is found, it defaults to using locally installed python 3.X 