### PR TITLE
setup.cfg changes to correct dependency installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,15 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
+python_requires = >=3.10.0
 install_requires =
-    numpy;python_version>'3.10.0'
-    scipy;python_version>'3.10.0'
-    matplotlib;python_version>'3.10.0'
-    opencv-python;python_version>'3.10.0'
-    configparser;python_version>'3.10.0'
-    astropy;python_version>'3.10.0'
-    sep;python_version>'3.10.0'
-    pdoc;python_version>'3.10.0'
+    numpy
+    scipy
+    matplotlib
+    opencv-python
+    astropy
+    sep
+    pdoc
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Some changes to setup.cfg include:

* Removal of `configparser` as dependency since this is built into Python's STL
* Added `[options].python_requires` argument, which corrects dependency installation whereas before local and PyPI pip installation of `shapelets` library would not install dependencies!

This PR fixes issue #51 