### PR TITLE
Introduction of n=1 orthonormal polar shapelet functions with supportive changes

### DIFF
--- a/shapelets/functions.py
+++ b/shapelets/functions.py
@@ -24,7 +24,8 @@ __all__ = [
     'cartesian1D',
     'cartesian2D',
     'polar2D',
-    'orthonormalpolar2D',
+    'orthonormalpolar2D_n0',
+    'orthonormalpolar2D_n1',
     'exponential1D',
     'exponential2D'
 ]
@@ -185,13 +186,13 @@ def polar2D(n: int, m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndar
 
     return Sc(x1, x2)
 
-def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
+def orthonormalpolar2D_n0(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
     r""" 
     Orthonormal 2D polar shapelet function defined as[1]_,
 
     $$ S_{m}(r, \theta; \beta) = \frac{1}{\beta \sqrt{\pi m!}} \left( \frac{r}{\beta} \right)^m exp \left( -\frac{r^2}{2\beta^2}-im\theta \right) $$
 
-    with $$ \beta = \frac{fl}{\sqrt{m}} $$
+    with $$ \beta = \frac{fl}{\sqrt{m}} $$, and
 
     where $\beta$ is the shapelet length scale, $f$ is a geometric scale factor[1]_, $l$ is the characteristic wavelength of the image[2]_, and $m$ is the shapelet degree of rotational symmetry.
 
@@ -213,7 +214,7 @@ def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.n
 
     Notes
     -----
-    The orthonormal shapelet framework[1]_ only supports $n = 0$. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of that found in shapelets.functions.polar2D.
+    This orthonormal shapelet framework[1]_ was developed for $n = 0$ polar shapelets[2]_. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of the shapelets.functions.polar2D function by ref.[2]_.
 
     References
     ----------
@@ -234,6 +235,57 @@ def orthonormalpolar2D(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.n
     # shapelet function
     X = lambda r: r**m * L(r**2) * np.exp(-r**2 / 2)
     Sp = lambda r,t: beta**-1 * c * X(r/beta) * np.exp(-1j*m*t)
+    Sc = lambda x,y: Sp(np.sqrt(x**2 + y**2), np.arctan2(y,x))
+
+    return Sc(x1, x2)
+
+def orthonormalpolar2D_n1(m: int, x1: Union[float,np.ndarray], x2: Union[float,np.ndarray], beta: float = 1.) -> Union[float,np.ndarray]:
+    r""" 
+    Orthonormal 2D polar shapelet function one degree of radial symmetry defined as[1]_,
+
+    $$ S_{m}(r, \theta; \beta) = \frac{r^m \beta^{-(m+1)}}{\sqrt{\pi m! (m+1)}}
+                                \left[ 1 + m- \left( \frac{r}{\beta}\right)^2 \right] 
+                                e^{-\frac{r^2}{2\beta^2}} e^{-im\theta} $$
+
+    with $$ \beta $$ computed numerically[1]_, and
+
+    where $\beta$ is the shapelet length scale, $l$ is the characteristic wavelength of the image[2]_, and $m$ is the shapelet degree of rotational symmetry.
+
+    Parameters
+    ----------
+    * m: int
+        * Shapelet degree of rotational symmetry. Acceptable values are $m > 1$
+    * x1: Union[float,np.ndarray]
+        * First input to shapelet function
+    * x2: Union[float,np.ndarray]
+        * Second input to shapelet function
+    * beta: float
+        * The shapelet length scale parameter
+
+    Returns
+    -------
+    * Sc(x1, x2): Union[float,np.ndarray]
+        * Shapelet function evaluated at (x1, x2)
+
+    Notes
+    -----
+    This orthonormal shapelet framework[1]_ was developed for $n = 1$ polar shapelets[2]_. See ref.[2]_ for computing the characteristic wavelength of an image. Note that this shapelet formulation is a re-parameterization of the shapelets.functions.polar2D function by ref.[2]_.
+
+    References
+    ----------
+    .. [1] https://hdl.handle.net/10012/20779
+    .. [2] http://dx.doi.org/10.1103/PhysRevE.91.033307
+
+    """
+    if m < 1:
+        raise ValueError("Function only supports m >= 1.")
+
+    # weighting constant
+    c = 1 / ( np.sqrt(np.pi * factorial(m, exact=True) * (m+1)) )
+
+    # shapelet function
+    X = lambda r: r**m * (1+m-(r**2)) * np.exp(-0.5 * r**2)
+    Sp = lambda r,t: (c / beta) * X(r/beta) * np.exp(-1j*m*t)
     Sc = lambda x,y: Sp(np.sqrt(x**2 + y**2), np.arctan2(y,x))
 
     return Sc(x1, x2)

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -26,45 +26,11 @@ from scipy.ndimage import median_filter
 from .wavelength import get_wavelength
 
 __all__ = [
-    'make_grid',
     'read_image',
     'process_output',
     'image_difference',
     'trim_image'
 ]
-
-def make_grid(N: int):
-    r""" 
-    Make discretized grid based on width (N).
-    
-    Parameters
-    ----------
-    * N: int
-        * The width of the kernel (odd numbers only)
-
-    Returns
-    -------
-    * grid_x: np.ndarray
-        * The grid's x coordinate space
-    * grid_y: np.ndarray
-        * The grid's y coordinate space
-    
-    Notes
-    -----
-    As per convention, N should only be an odd number. Additionally, note that grid_x = grid_y.
-
-    """
-    if N % 2 == 0:
-        print('Detected even grid size, adding 1 to enforce odd rule See self_assembly.misc.make_grid() docs.')
-        N += 1
-    if N < 3:
-        raise ValueError('N must be at least 3 or greater.')
-    
-    bounds = [-(N-1)/2.0, (N-1)/2.0]
-    grid = np.linspace(bounds[0], bounds[1], N)
-    grid_x, grid_y = np.meshgrid(grid, grid)
-
-    return grid_x, grid_y
 
 def read_image(image_name: str, image_path: str, verbose: bool = True):
     r""" 

--- a/shapelets/self_assembly/misc.py
+++ b/shapelets/self_assembly/misc.py
@@ -32,7 +32,7 @@ __all__ = [
     'trim_image'
 ]
 
-def read_image(image_name: str, image_path: str, verbose: bool = True):
+def read_image(image_name: str, image_path: str, verbose: bool = True) -> np.ndarray:
     r""" 
     Read an image using OpenCV, with some extra handling. By default, re-scales images as greyscale on [-1, 1].
     

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -30,7 +30,7 @@ from scipy.ndimage import grey_dilation, median_filter
 
 from .misc import trim_image, make_grid
 from .wavelength import get_wavelength, lambda_to_beta
-from ..functions import orthonormalpolar2D
+from ..functions import orthonormalpolar2D_n0
 
 __all__ = [
     'convresponse',
@@ -63,7 +63,7 @@ def convresponse(image: np.ndarray, shapelet_order: Union[str,int] = 'default', 
 
     Notes
     -----
-    This function uses the orthonormal polar shapelet definition[1]_ (see shapelets.functions.orthonormalpolar2D).
+    This function uses the orthonormal polar shapelet definition[1]_ (see shapelets.functions.orthonormalpolar2D_n0).
 
     References
     ----------
@@ -107,7 +107,7 @@ def convresponse(image: np.ndarray, shapelet_order: Union[str,int] = 'default', 
             # get grid for discretization and initialize shapelet kernel
             N = 21 # minimum
             grid_x, grid_y = make_grid(N = N)
-            shapelet = orthonormalpolar2D(m=i+1, x1=grid_x, x2=grid_y, beta=beta)
+            shapelet = orthonormalpolar2D_n0(m=i+1, x1=grid_x, x2=grid_y, beta=beta)
 
             # optimize shapelet (kernel) size
             accept = False
@@ -118,7 +118,7 @@ def convresponse(image: np.ndarray, shapelet_order: Union[str,int] = 'default', 
                 if edgeweight > 0.0001:
                     N += 4
                     grid_x, grid_y = make_grid(N = N)
-                    shapelet = orthonormalpolar2D(m=i+1, x1=grid_x, x2=grid_y, beta=beta)
+                    shapelet = orthonormalpolar2D_n0(m=i+1, x1=grid_x, x2=grid_y, beta=beta)
                 else:
                     accept = True
 
@@ -142,7 +142,7 @@ def convresponse(image: np.ndarray, shapelet_order: Union[str,int] = 'default', 
             # get grid for discretization and initialize shapelet kernel
             N = 21 # minimum
             grid_x, grid_y = make_grid(N = N)
-            shapelet = orthonormalpolar2D(m=m, x1=grid_x, x2=grid_y, beta=beta)
+            shapelet = orthonormalpolar2D_n0(m=m, x1=grid_x, x2=grid_y, beta=beta)
 
             # optimize shapelet (kernel) size
             accept = False
@@ -153,7 +153,7 @@ def convresponse(image: np.ndarray, shapelet_order: Union[str,int] = 'default', 
                 if edgeweight > 0.0001:
                     N += 4
                     grid_x, grid_y = make_grid(N = N)
-                    shapelet = orthonormalpolar2D(m=m, x1=grid_x, x2=grid_y, beta=beta)
+                    shapelet = orthonormalpolar2D_n0(m=m, x1=grid_x, x2=grid_y, beta=beta)
                 else:
                     accept = True
             
@@ -479,18 +479,19 @@ def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shape
     
     # TODO: both implementations should use 2d arrays (fix python implementation)
     
-    import platform
-
     ti = time.time()
 
     try:
-        print("Attempting to use C++ implementation of response distance")
+        if verbose: 
+            print("Attempting to use C++ implementation of response distance")
 
         response_2d = np.reshape(response, (-1, response.shape[-1]))
         d_1d = _rdistance(response_ref, response_2d)
         d = d_1d.reshape(Ny, Nx)
+
     except:
-        print("C++ implementation failed, using Python implementation")
+        if verbose: 
+            print("C++ implementation failed, using Python implementation")
 
         d = np.zeros((Ny, Nx))
         compList = np.array([10, 25, 50, 75, 100]).astype(int)

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -28,7 +28,6 @@ __all__ = [
     'lambda_to_beta_n1',
     'get_opt_kernel_n1',
     'get_wavelength',
-    'radialavg',
 ]
 
 def make_grid(N: int):
@@ -121,11 +120,12 @@ def get_opt_kernel_n0(m: int, beta: float) -> np.ndarray:
     .. [1] https://doi.org/10.1088/1361-6528/aaf353
 
     """
+    # start with small kernel size and scale up until satisfied
     N = 21 # minimum
+
     grid_x, grid_y = make_grid(N = N)
     shapelet = orthonormalpolar2D_n0(m=m, x1=grid_x, x2=grid_y, beta=beta)
 
-    # optimize shapelet (kernel) size
     accept = False
 
     while not accept:
@@ -196,7 +196,8 @@ def lambda_to_beta_n1(m: int, l: float, verbose=False) -> float:
             if verbose:
                 print(f"Current distance {distance}, target is {lambda_opt}")
 
-            # check if solution is acceptable:
+            ## evaluate acceptability of solution ##
+
             # found solution
             if np.abs(reldistance) <= 1:
                 beta_opt = beta
@@ -211,7 +212,7 @@ def lambda_to_beta_n1(m: int, l: float, verbose=False) -> float:
                 else: 
                     beta += 3*reldistance * 0.1
 
-            # overshot
+            # overshot solution
             elif reldistance < 0:
                 if verbose:
                     print("We have overshot target, iterating backwards.")
@@ -221,8 +222,8 @@ def lambda_to_beta_n1(m: int, l: float, verbose=False) -> float:
 
 def get_opt_kernel_n1(m: int, beta: float) -> np.ndarray:
     r""" 
-    Determines the optimal filter (kernel) width for an $n=1$ shapelet function based on $\beta$, the shapelet length-scale parameter.
-    
+    Determines the optimal filter (kernel) width for an $n=1$ orthonormal polar shapelet function[1]_ based on $\beta$, the shapelet length-scale parameter.
+
     Parameters
     ----------
     * m: int
@@ -235,13 +236,17 @@ def get_opt_kernel_n1(m: int, beta: float) -> np.ndarray:
     * shapelet: np.ndarray
         * Shapelet function casted onto a discrete domain with the appropriate filter width.
 
+    References
+    ----------
+    .. [1] https://hdl.handle.net/10012/20779
+
     """
     # start with large kernel size and truncate down until satisfied
     N = 501
+
     grid_x, grid_y = make_grid(N = N)
     shapelet = orthonormalpolar2D_n1(m=m, x1=grid_x, x2=grid_y, beta=beta)
 
-    # optimize shapelet (kernel) size
     accept = False
 
     while not accept:
@@ -256,18 +261,16 @@ def get_opt_kernel_n1(m: int, beta: float) -> np.ndarray:
 
     return shapelet
 
-def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True) -> float:
+def get_wavelength(image: np.ndarray, rng: list = [0, 70], verbose: bool = True) -> float:
     r""" 
-    Find characteristic wavelength of an image. Computed from ref.[1]_.
-
-    mpt@mpt: The rng needs to be optimized better. For example, if the wavelength is bigger than 50 need to fix this. But, if we just let rng = None (i.e., all wavelengths) then it will find way too big of a wavelength as the scale...
+    Find characteristic wavelength of an image. Computed using method described in ref.[1]_.
     
     Parameters
     ----------
     * image: np.ndarray
         * The image to be processed
     * rng: list
-        * Range of wavelengths to consider for maximum wavelength. I.e., will return max wavelength in range of [0, 50] (default)
+        * Range of wavelengths to consider for maximum wavelength. I.e., will return max wavelength in range of [0, 70] (default)
 
     Returns
     -------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -26,7 +26,7 @@ __all__ = [
 
 def lambda_to_beta(m: int, l: float):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ (see shapelets.functions.orthonormalpolar2D).
+    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ (see shapelets.functions.orthonormalpolar2D_n0).
     
     Parameters
     ----------

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -19,14 +19,54 @@ import numbers
 
 import numpy as np
 
+from ..functions import orthonormalpolar2D_n0, orthonormalpolar2D_n1
+
 __all__ = [
-    'lambda_to_beta',
+    'make_grid',
+    'lambda_to_beta_n0',
+    'get_opt_kernel_n0',
+    'lambda_to_beta_n1',
+    'get_opt_kernel_n1',
     'get_wavelength',
+    'radialavg',
 ]
 
-def lambda_to_beta(m: int, l: float):
+def make_grid(N: int):
     r""" 
-    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ (see shapelets.functions.orthonormalpolar2D_n0).
+    Make discretized grid based on width (N).
+    
+    Parameters
+    ----------
+    * N: int
+        * The width of the kernel (odd numbers only)
+
+    Returns
+    -------
+    * grid_x: np.ndarray
+        * The grid's x coordinate space
+    * grid_y: np.ndarray
+        * The grid's y coordinate space
+    
+    Notes
+    -----
+    As per convention, N should only be an odd number. Additionally, note that grid_x = grid_y.
+
+    """
+    if N % 2 == 0:
+        print('Detected even grid size, adding 1 to enforce odd rule See self_assembly.wavelength.make_grid() docs.')
+        N += 1
+    if N < 3:
+        raise ValueError('N must be at least 3 or greater.')
+    
+    bounds = [-(N-1)/2.0, (N-1)/2.0]
+    grid = np.linspace(bounds[0], bounds[1], N)
+    grid_x, grid_y = np.meshgrid(grid, grid)
+
+    return grid_x, grid_y
+
+def lambda_to_beta_n0(m: int, l: float) -> float:
+    r""" 
+    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ with $n=0$ (see shapelets.functions.orthonormalpolar2D_n0).
     
     Parameters
     ----------
@@ -60,7 +100,163 @@ def lambda_to_beta(m: int, l: float):
     beta = (l / np.sqrt(m)) * f
     return beta
 
-def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True):
+def get_opt_kernel_n0(m: int, beta: float) -> np.ndarray:
+    r""" 
+    Determines the optimal filter (kernel) width for an $n=0$ orthonormal polar shapelet function[1]_ based on $\beta$, the shapelet length-scale parameter.
+    
+    Parameters
+    ----------
+    * m: int
+        * Shapelet degree of rotational symmetry
+    * beta: float
+        * The characteristic shapelet length scale parameter.
+    
+    Returns
+    -------
+    * shapelet: np.ndarray
+        * Shapelet function casted onto a discrete domain with the appropriate filter width.
+
+    References
+    ----------
+    .. [1] https://doi.org/10.1088/1361-6528/aaf353
+
+    """
+    N = 21 # minimum
+    grid_x, grid_y = make_grid(N = N)
+    shapelet = orthonormalpolar2D_n0(m=m, x1=grid_x, x2=grid_y, beta=beta)
+
+    # optimize shapelet (kernel) size
+    accept = False
+
+    while not accept:
+        edgeweight = np.abs(np.real(shapelet[int(shapelet.shape[0]/2), -1])) \
+            / np.real(shapelet).max()
+        if edgeweight > 0.0001:
+            N += 4
+            grid_x, grid_y = make_grid(N = N)
+            shapelet = orthonormalpolar2D_n0(m=m, x1=grid_x, x2=grid_y, beta=beta)
+        else:
+            accept = True
+    
+    return shapelet
+
+def lambda_to_beta_n1(m: int, l: float, verbose=False) -> float:
+    r""" 
+    Converts lambda (l), the characteristic wavelength of the image[1]_ to the appropriate beta value for orthonormal polar shapelets[2]_ with $n=1$ (see shapelets.functions.orthonormalpolar2D_n1).
+    
+    Parameters
+    ----------
+    * m: int
+        * Shapelet degree of rotational symmetry
+    * l: float
+        * The characteristic wavelength of the image[1]_
+    
+    Returns
+    -------
+    * beta: float
+        * The characteristic shapelet length scale parameter based on ref.[2]_
+
+    References
+    ----------
+    .. [1] http://dx.doi.org/10.1103/PhysRevE.91.033307
+    .. [2] https://hdl.handle.net/10012/20779
+
+    """
+    lambda_opt = np.round(l*1.5, 0)
+    beta = 1
+
+    accept = False
+
+    while not accept:
+
+        # get appropriate sized kernel
+        shapelet = get_opt_kernel_n1(m = m, beta = beta)
+
+        # extract the midline to work with 1D data for simplicity
+        halfpoint = int((shapelet.shape[0] - 1) / 2)
+        data = np.real(shapelet[halfpoint, :])
+
+        # now find the two peaks associated with two max / min of inner/outer shapelet lobes
+        numpts = data.size
+        peak_ind = np.array([])
+        for p in range(halfpoint+1, numpts-1): # check all points except for the ends
+            if (data[p-1] < data[p] > data[p+1]) or (data[p-1] > data[p] < data[p+1]):
+                peak_ind = np.append(peak_ind, p)
+
+        if peak_ind.size != 2:
+            print("Error in expected number of peaks... kernel error. Skipping iteration...")
+            breakpoint()
+            beta += 2*0.1
+
+        else:
+            # want {peak_HP - halfpoint} to be close to 1.5*lambda
+            peak_MP = np.round((peak_ind[1] - peak_ind[0]) / 2, 0) + peak_ind[0]
+            distance = peak_MP - halfpoint
+            reldistance = lambda_opt - distance
+            if verbose:
+                print(f"Current distance {distance}, target is {lambda_opt}")
+
+            # check if solution is acceptable:
+            # found solution
+            if np.abs(reldistance) <= 1:
+                beta_opt = beta
+                if verbose: print(f"optimum beta found to be {beta_opt}")
+                accept = True # stop
+
+            # undershot solution
+            if reldistance > 0:
+                # adaptive stepping to speed up computations
+                if reldistance < 2:
+                    beta += 0.1
+                else: 
+                    beta += 3*reldistance * 0.1
+
+            # overshot
+            elif reldistance < 0:
+                if verbose:
+                    print("We have overshot target, iterating backwards.")
+                beta -= reldistance*0.1
+    
+    return beta_opt
+
+def get_opt_kernel_n1(m: int, beta: float) -> np.ndarray:
+    r""" 
+    Determines the optimal filter (kernel) width for an $n=1$ shapelet function based on $\beta$, the shapelet length-scale parameter.
+    
+    Parameters
+    ----------
+    * m: int
+        * Shapelet degree of rotational symmetry
+    * beta: float
+        * The characteristic shapelet length scale parameter.
+    
+    Returns
+    -------
+    * shapelet: np.ndarray
+        * Shapelet function casted onto a discrete domain with the appropriate filter width.
+
+    """
+    # start with large kernel size and truncate down until satisfied
+    N = 501
+    grid_x, grid_y = make_grid(N = N)
+    shapelet = orthonormalpolar2D_n1(m=m, x1=grid_x, x2=grid_y, beta=beta)
+
+    # optimize shapelet (kernel) size
+    accept = False
+
+    while not accept:
+        edgeweight = np.abs(np.real(shapelet[int(shapelet.shape[0]/2), -1])) / np.real(shapelet).max()
+
+        if edgeweight < 0.001:
+            N -= 4
+            grid_x, grid_y = make_grid(N = N)
+            shapelet = orthonormalpolar2D_n1(m=m, x1=grid_x, x2=grid_y, beta=beta)
+        else:
+            accept = True
+
+    return shapelet
+
+def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True) -> float:
     r""" 
     Find characteristic wavelength of an image. Computed from ref.[1]_.
 
@@ -120,7 +316,7 @@ def get_wavelength(image: np.ndarray, rng: list = [0, 50], verbose: bool = True)
     
     return rai_wave[i_max]
 
-def radialavg(image: np.ndarray):
+def radialavg(image: np.ndarray) -> np.ndarray:
     r""" 
     Calculates the radially averaged intensity of an image. Based on work from ref.[1]_.
     

--- a/shapelets/tests/test_self_assembly_basic.py
+++ b/shapelets/tests/test_self_assembly_basic.py
@@ -24,7 +24,7 @@ import numpy as np
 from shapelets.self_assembly import (
     read_image, 
     get_wavelength,
-    lambda_to_beta
+    lambda_to_beta_n0
 )
 
 class TestSelfAssemblyBasic(unittest.TestCase):
@@ -34,7 +34,7 @@ class TestSelfAssemblyBasic(unittest.TestCase):
     Currently includes:
         - self_assembly.misc.read_image, 
         - self_assembly.wavelength.get_wavelength, and
-        - self_assembly.wavelength.lambda_to_beta
+        - self_assembly.wavelength.lambda_to_beta_n0
     """
 
     @classmethod
@@ -56,7 +56,7 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertEqual(self.hexSIM.max(), 1)
         self.assertEqual(self.hexSIM.shape, (507, 507))
     
-    # Test get_wavelength() and lambda_to_beta()
+    # Test get_wavelength() and lambda_to_beta_n0()
     def test_scale(self) -> None:
         with self.assertRaises(TypeError):
             get_wavelength('')
@@ -65,7 +65,7 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertTrue(isinstance(lamSIM_wvl, numbers.Real))
         self.assertAlmostEqual(lamSIM_wvl, 10.231, places = 3)
 
-        lamSIM_beta = lambda_to_beta(3, lamSIM_wvl)
+        lamSIM_beta = lambda_to_beta_n0(3, lamSIM_wvl)
         self.assertTrue(isinstance(lamSIM_beta, numbers.Real))
         self.assertAlmostEqual(lamSIM_beta, 3.41, places = 2)
 
@@ -73,9 +73,11 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertTrue(isinstance(hexSIM_wvl, numbers.Real))
         self.assertAlmostEqual(hexSIM_wvl, 16.882, places = 3)
         
-        hexSIM_beta = lambda_to_beta(6, hexSIM_wvl)
+        hexSIM_beta = lambda_to_beta_n0(6, hexSIM_wvl)
         self.assertTrue(isinstance(hexSIM_beta, numbers.Real))
         self.assertAlmostEqual(hexSIM_beta, 6.89, places = 2)
+
+        #TODO lambda_to_beta_n1
 
 
 if __name__ == "__main__":

--- a/shapelets/tests/test_self_assembly_basic.py
+++ b/shapelets/tests/test_self_assembly_basic.py
@@ -24,7 +24,8 @@ import numpy as np
 from shapelets.self_assembly import (
     read_image, 
     get_wavelength,
-    lambda_to_beta_n0
+    lambda_to_beta_n0,
+    lambda_to_beta_n1
 )
 
 class TestSelfAssemblyBasic(unittest.TestCase):
@@ -43,9 +44,8 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         cls.lamSIM = read_image(image_name = "lamSIM1.png", image_path = cls.dir, verbose = False)
         cls.hexSIM = read_image(image_name = "hexSIM1.png", image_path = cls.dir, verbose = False)
 
-    # This test will be fun first on purpose
-    # Test read_image()
-    def test_a_first(self) -> None:
+    # This test will be fun first on purpose. Test read_image
+    def test_a_read_image(self) -> None:
         self.assertTrue(isinstance(self.lamSIM, np.ndarray))
         self.assertEqual(self.lamSIM.min(), -1)
         self.assertEqual(self.lamSIM.max(), 1)
@@ -56,8 +56,8 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertEqual(self.hexSIM.max(), 1)
         self.assertEqual(self.hexSIM.shape, (507, 507))
     
-    # Test get_wavelength() and lambda_to_beta_n0()
-    def test_scale(self) -> None:
+    # Test get_wavelength 
+    def test_scaling(self) -> None:
         with self.assertRaises(TypeError):
             get_wavelength('')
 
@@ -65,20 +65,25 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertTrue(isinstance(lamSIM_wvl, numbers.Real))
         self.assertAlmostEqual(lamSIM_wvl, 10.231, places = 3)
 
-        lamSIM_beta = lambda_to_beta_n0(3, lamSIM_wvl)
-        self.assertTrue(isinstance(lamSIM_beta, numbers.Real))
-        self.assertAlmostEqual(lamSIM_beta, 3.41, places = 2)
+        lamSIM_beta_n0 = lambda_to_beta_n0(3, lamSIM_wvl)
+        self.assertTrue(isinstance(lamSIM_beta_n0, numbers.Real))
+        self.assertAlmostEqual(lamSIM_beta_n0, 3.41, places = 2)
+
+        lamSIM_beta_n1 = lambda_to_beta_n1(3, lamSIM_wvl)
+        self.assertTrue(isinstance(lamSIM_beta_n1, numbers.Real))
+        self.assertAlmostEqual(lamSIM_beta_n1, 7.3, places = 5)
 
         hexSIM_wvl = get_wavelength(image = self.hexSIM, verbose = False)
         self.assertTrue(isinstance(hexSIM_wvl, numbers.Real))
         self.assertAlmostEqual(hexSIM_wvl, 16.882, places = 3)
         
-        hexSIM_beta = lambda_to_beta_n0(6, hexSIM_wvl)
-        self.assertTrue(isinstance(hexSIM_beta, numbers.Real))
-        self.assertAlmostEqual(hexSIM_beta, 6.89, places = 2)
+        hexSIM_beta_n0 = lambda_to_beta_n0(6, hexSIM_wvl)
+        self.assertTrue(isinstance(hexSIM_beta_n0, numbers.Real))
+        self.assertAlmostEqual(hexSIM_beta_n0, 6.89, places = 2)
 
-        #TODO lambda_to_beta_n1
-
+        hexSIM_beta_n1 = lambda_to_beta_n1(6, hexSIM_wvl)
+        self.assertTrue(isinstance(hexSIM_beta_n1, numbers.Real))
+        self.assertAlmostEqual(hexSIM_beta_n1, 9.1, places = 5)
 
 if __name__ == "__main__":
     unittest.main()

--- a/shapelets/tests/test_self_assembly_methods.py
+++ b/shapelets/tests/test_self_assembly_methods.py
@@ -15,16 +15,14 @@
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
 
-import numbers 
 import os
 import unittest
 
 import numpy as np
 
 from shapelets.self_assembly import (
-    read_image, 
-    get_wavelength,
-    convresponse,
+    read_image,
+    convresponse_n0,
     defectid,
     orientation,
     rdistance
@@ -47,7 +45,7 @@ class TestSelfAssemblyMethods(unittest.TestCase):
         cls.image = read_image(image_name="hexSIM1.png", image_path=cls.dir, verbose=False)
         assert isinstance(cls.image, np.ndarray)
 
-        cls.omega, cls.phi = convresponse(cls.image, shapelet_order='default', verbose=False)
+        cls.omega, cls.phi = convresponse_n0(cls.image, shapelet_order='default', verbose=False)
     
     # This test will be run first on purpose
     def test_a_first(self) -> None:
@@ -57,24 +55,23 @@ class TestSelfAssemblyMethods(unittest.TestCase):
         self.assertTrue(isinstance(self.phi, np.ndarray))
         self.assertEqual(self.phi.shape, self.image.shape + (10,))
 
-    def test_convresponse(self) -> None:
+    def test_convresponse_n0(self) -> None:
         with self.assertRaises(TypeError):
-            convresponse([], shapelet_order='default')
+            convresponse_n0([], shapelet_order='default')
 
         with self.assertRaises(ValueError): 
-            convresponse(self.image, shapelet_order='')
+            convresponse_n0(self.image, shapelet_order='')
         with self.assertRaises(TypeError):
-            convresponse(self.image, shapelet_order=5.)
-        
-        with self.assertRaises(TypeError):
-            convresponse(self.image, shapelet_order='default', normresponse=[])
-        with self.assertRaises(ValueError):
-            convresponse(self.image, shapelet_order='default', normresponse='')
+            convresponse_n0(self.image, shapelet_order=5.)
 
         # Test non-default input of shapelet_order parameter 
-        omega, phi = convresponse(self.image, shapelet_order=20, verbose=False)
+        omega, phi = convresponse_n0(self.image, shapelet_order=20, verbose=False)
         self.assertEqual(omega.shape, self.image.shape + (20,))
         self.assertEqual(phi.shape, self.image.shape + (20,))
+    
+    def test_convresponse_n1(self) -> None:
+        # TODO
+        pass
     
     # Note: cannot test outputs as defectid() is an interactive function.
     def test_defectid(self) -> None:

--- a/shapelets/tests/test_self_assembly_methods.py
+++ b/shapelets/tests/test_self_assembly_methods.py
@@ -23,6 +23,7 @@ import numpy as np
 from shapelets.self_assembly import (
     read_image,
     convresponse_n0,
+    convresponse_n1,
     defectid,
     orientation,
     rdistance
@@ -48,7 +49,7 @@ class TestSelfAssemblyMethods(unittest.TestCase):
         cls.omega, cls.phi = convresponse_n0(cls.image, shapelet_order='default', verbose=False)
     
     # This test will be run first on purpose
-    def test_a_first(self) -> None:
+    def test_a_responses(self) -> None:
         self.assertTrue(isinstance(self.omega, np.ndarray))
         self.assertEqual(self.omega.shape, self.image.shape + (10,))
 
@@ -70,8 +71,16 @@ class TestSelfAssemblyMethods(unittest.TestCase):
         self.assertEqual(phi.shape, self.image.shape + (20,))
     
     def test_convresponse_n1(self) -> None:
-        # TODO
-        pass
+        with self.assertRaises(TypeError):
+            convresponse_n1([], mmax=5)
+
+        with self.assertRaises(TypeError):
+            convresponse_n1(self.image, mmax=5.2)
+        
+        # Test for arbitrary number of shapelets
+        omega, phi = convresponse_n1(self.image, mmax=6, verbose=False)
+        self.assertEqual(omega.shape, self.image.shape + (6,))
+        self.assertEqual(phi.shape, self.image.shape + (6,))
     
     # Note: cannot test outputs as defectid() is an interactive function.
     def test_defectid(self) -> None:

--- a/shapelets/tests/test_shapelet_functions.py
+++ b/shapelets/tests/test_shapelet_functions.py
@@ -23,7 +23,8 @@ from shapelets.functions import (
     cartesian1D,
     cartesian2D,
     polar2D,
-    orthonormalpolar2D,
+    orthonormalpolar2D_n0,
+    orthonormalpolar2D_n1,
     exponential1D,
     exponential2D
 )
@@ -34,7 +35,7 @@ class TestShapeletFunctions(unittest.TestCase):
     Currently includes,
         - cartesian shapelets (shapelets.functions.cartesian1D and shapelets.functions.cartesian2D),
         - polar shapelets (shapelets.functions.polar2D),
-        - orthonormal polar shapelets (shapelets.functions.orthonormalpolar2D), and
+        - orthonormal polar shapelets (shapelets.functions.orthonormalpolar2D_n0), and
         - exponential shapelets (shapelets.functions.exponential1D and shapelets.functions.exponential2D)
     """
 
@@ -84,8 +85,8 @@ class TestShapeletFunctions(unittest.TestCase):
         with self.assertRaises(ValueError): 
             polar2D(n = 3, m = 2, x1 = self.xvals, x2 = self.xvals)
     
-    def test_orthonormal(self) -> None:
-        shapelet2D = orthonormalpolar2D(m = 6, x1 = self.xvals, x2 = self.xvals)
+    def test_orthonormal_n0(self) -> None:
+        shapelet2D = orthonormalpolar2D_n0(m = 6, x1 = self.xvals, x2 = self.xvals)
 
         self.assertTrue(np.iscomplexobj(shapelet2D))
 
@@ -94,7 +95,19 @@ class TestShapeletFunctions(unittest.TestCase):
         self.assertAlmostEqual(np.real(shapelet2D[2]), 0., places = 16)
 
         with self.assertRaises(ValueError): 
-            orthonormalpolar2D(m = 0, x1 = self.xvals, x2 = self.xvals)
+            orthonormalpolar2D_n0(m = 0, x1 = self.xvals, x2 = self.xvals)
+    
+    def test_orthonormal_n1(self) -> None:
+        shapelet2D = orthonormalpolar2D_n1(m = 3, x1 = self.xvals, x2 = self.xvals)
+
+        self.assertTrue(np.iscomplexobj(shapelet2D))
+
+        self.assertEqual(shapelet2D[1], 0)
+        self.assertAlmostEqual(np.real(shapelet2D[0]), 0.1694669, places = 7)
+        self.assertAlmostEqual(np.imag(shapelet2D[2]), -0.1694669, places = 7)
+
+        with self.assertRaises(ValueError): 
+            orthonormalpolar2D_n0(m = 0, x1 = self.xvals, x2 = self.xvals)
     
     def test_exponential(self) -> None:
         shapelet1D = exponential1D(n = 1, x1 = self.xvals+1)


### PR DESCRIPTION
These commits add the orthonormal n=1 polar shapelet function definition [1] with supporting changes, such as:

* function to compute convolutions between n=1 shapelet filters and images similar to the existing structure for n=0 filters,
* scaling functions to compute $\beta$ and appropriate filter widths using a numerical scheme from ref. [1],
* unit tests to support the new shapelet function and the aforementioned additional functions, and
* minor changes to accompany these new functions (i.e., renaming of older functions by appending **_n0** to differentiate between new (n=1) and existing (n=0) functions.

[1] https://hdl.handle.net/10012/20779