### PR TITLE
Corrected optimal filter orientation for steerable shapelets

### DIFF
--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -200,7 +200,8 @@ def orientation(image: np.ndarray, pattern_order: str, verbose: bool = True):
     for i in range(omega.shape[2]):
             omega[:,:,i] =  (omega[:,:,i] - omega[:,:,i].min()) / ( omega[:,:,i].max() - omega[:,:,i].min())
 
-    # to correct angles on [0, 2pi/m] as per steerable shapelet theory.
+    # to correct angles on [0, 2pi/m] as per the local orientation method from ref. [1]
+    # NOTE: this is not exactly equivalent to the optimal filter orientation from steerable filter theory, but has minor modifications
     for i in range(phi.shape[2]):
         phi[:,:,i] = (phi[:,:,i] - phi[:,:,i].min()) / (phi[:,:,i].max() - phi[:,:,i].min())
         phi[:,:,i] *=  2*np.pi / (i+1)

--- a/shapelets/tests/test_self_assembly_methods.py
+++ b/shapelets/tests/test_self_assembly_methods.py
@@ -64,6 +64,8 @@ class TestSelfAssemblyMethods(unittest.TestCase):
             convresponse_n0(self.image, shapelet_order='')
         with self.assertRaises(TypeError):
             convresponse_n0(self.image, shapelet_order=5.)
+        with self.assertRaises(ValueError):
+            convresponse_n0(self.image, shapelet_order=-1)
 
         # Test non-default input of shapelet_order parameter 
         omega, phi = convresponse_n0(self.image, shapelet_order=20, verbose=False)
@@ -76,6 +78,8 @@ class TestSelfAssemblyMethods(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             convresponse_n1(self.image, mmax=5.2)
+        with self.assertRaises(ValueError):
+            convresponse_n1(self.image, mmax=-1)
         
         # Test for arbitrary number of shapelets
         omega, phi = convresponse_n1(self.image, mmax=6, verbose=False)


### PR DESCRIPTION
This PR corrects a small bug where optimal shapelet filter orientations were normalized before adhering to the steerable shapelet formulism as per Section 2.3.2 of https://hdl.handle.net/10012/20779. 

Also, minor input checks were added for convolution functions as well as two new unit tests.