### PR TITLE
MNT: Simplified default value handling for num_clusters parameter

### DIFF
--- a/examples/example_1/config
+++ b/examples/example_1/config
@@ -4,6 +4,6 @@ method = response_distance
 
 [response_distance]
 shapelet_order = default
-num_clusters = default
+num_clusters = 20
 ux = [50, 80]
 uy = [150, 180]

--- a/examples/example_1/example_1.md
+++ b/examples/example_1/example_1.md
@@ -49,7 +49,7 @@ The method outlined in the configuration file will also have its own header with
 **shapelet_order** `int`
 
 * The maximum shapelet order ($m'$) used for convolution operations, i.e. $m \in [1, m']$ shapelets are used 
-* Default value is computed by the higher-order shapelet algorithm ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
+* Default value (via keyword *default* as shown above) allows $m'$ to be determined by the higher-order shapelet algorithm ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
 
 **num_clusters** `int`
 

--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -28,7 +28,7 @@ from shapelets.self_assembly import (
 ## Section 2: parameters
 image_name = "lamSIM1.png"
 shapelet_order = 'default' # can also be integer value to set upper bound
-num_clusters = 'default' # default is 20, can be any other positive integer 
+num_clusters = 20 # default is 20, can be any other positive integer 
 ux = [50, 80]
 uy = [150, 180]
 

--- a/shapelets/_run.py
+++ b/shapelets/_run.py
@@ -18,7 +18,6 @@
 import ast
 import configparser
 import os
-from pathlib import Path
 
 from .astronomy.galaxy import *
 
@@ -77,9 +76,8 @@ def _run(config_file: str, working_dir: str) -> None:
             if shapelet_order != 'default':
                 shapelet_order = ast.literal_eval(shapelet_order)
 
-            num_clusters = config.get('response_distance', 'num_clusters', fallback = 'default')
-            if num_clusters != 'default':
-                num_clusters = ast.literal_eval(num_clusters)
+            num_clusters = config.get('response_distance', 'num_clusters', fallback = 20)
+            num_clusters = ast.literal_eval(num_clusters)
 
             ux = config.get('response_distance', 'ux', fallback = 'default')
             uy = config.get('response_distance', 'uy', fallback = 'default')

--- a/shapelets/self_assembly/quant.py
+++ b/shapelets/self_assembly/quant.py
@@ -243,7 +243,8 @@ def orientation(image: np.ndarray, pattern_order: str, verbose: bool = True):
 
     return mask, dilate, orientation_final, maxval
 
-def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shapelet_order: Union[str,int] = 'default', ux: Union[str,list] = 'default', uy: Union[str,list] = 'default', verbose: bool = True) -> np.ndarray:
+def rdistance(image: np.ndarray, num_clusters: int = 20, shapelet_order: Union[str,int] = 'default', 
+              ux: Union[str,list] = 'default', uy: Union[str,list] = 'default', verbose: bool = True) -> np.ndarray: 
     r""" 
     Compute the response distance method from ref. [1]. By default, attempts to use the fastest implementation (C++) as opposed to Python; defaults to Python upon error. 
 
@@ -251,10 +252,10 @@ def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shape
     ----------
     * image: numpy.ndarray
         * The image loaded as a numpy array
-    * num_clusters: Union[str,int]
-        * The number of clusters as input to k-means clustering [2]. If str, acceptable value is "default" (which uses 20 clusters [3])
+    * num_clusters: int
+        * The number of clusters as input to k-means clustering [2]. Default is 20 from ref. [3]. Can pass 0 to not use k-means clustering on reference region
     * shapelet_order: Union[str,int]
-        * Set as 'default' to use higher-order shapelets [4] ($m \leq m'$). Can also accept integer value such that analysis uses $m \in [1, shapelet_{order}]$
+        * Set as 'default' to use higher-order shapelets [4] ($m \leq m'$). Can also pass positive integer value for filter m upper bound
     * ux: Union[str,list]
         * The bounds in the x-direction for the reference region. If using list option, must be 2 element list. Choosing "default" will force user to choose ref. region during runtime
     * uy: Union[str,list]
@@ -278,23 +279,18 @@ def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shape
     if not isinstance(image, np.ndarray):
         raise TypeError('image must be a numpy array.')
         
-    if isinstance(num_clusters, str):
-        if num_clusters == 'default': 
-            num_clusters = 20
-        else:
-            raise ValueError('If num_clusters is str type, must be "default" otherwise use int.')
-    elif not isinstance(num_clusters, int):
-        raise TypeError('If num_clusters is not str type, must be int.')
+    if not isinstance(num_clusters, int):
+        raise TypeError('num_clusters must be int type.')
+    elif num_clusters < 0:
+        raise ValueError('num_clusters must be >= 0, see function documentation.')
 
     if type(ux) != type(uy):
         raise TypeError('ux and uy parameters must be both be "default" or both 2-element lists.')
-    
     elif isinstance(ux, str):
         if ux == 'default' and uy == 'default':
             choose_ref = True 
         else:
             raise ValueError('As str types, ux and uy parameters must be "default".')
-    
     elif isinstance(ux, list):
         if len(ux) != 2 or len(uy) != 2:
             raise ValueError('ux or uy has less or more than 2 elements.')
@@ -337,7 +333,7 @@ def rdistance(image: np.ndarray, num_clusters: Union[str,int] = 'default', shape
         plt.axis('off')
         plt.show()"""
     
-    # get convolutional response data, enforce shapelet_order parameter in convresponse() function
+    # get convolutional response data, enforce shapelet_order parameter checking inside function call
     response = convresponse_n0(image = image, shapelet_order = shapelet_order, verbose=verbose)[0]
 
     # compute response distance

--- a/shapelets/tests/test_self_assembly_methods.py
+++ b/shapelets/tests/test_self_assembly_methods.py
@@ -116,24 +116,24 @@ class TestSelfAssemblyMethods(unittest.TestCase):
             rdistance([])
         
         with self.assertRaises(ValueError):
-            rdistance(self.image, num_clusters='')
+            rdistance(self.image, num_clusters=-1)
         with self.assertRaises(TypeError):
             rdistance(self.image, num_clusters=1.)
 
         with self.assertRaises(TypeError):
-            rdistance(self.image, num_clusters='default', ux=[1, 2], uy='default')
+            rdistance(self.image, num_clusters=20, ux=[1, 2], uy='default')
         with self.assertRaises(ValueError):
-            rdistance(self.image, num_clusters='default', ux='incorrect', uy='default')
+            rdistance(self.image, num_clusters=20, ux='incorrect', uy='default')
         with self.assertRaises(ValueError):
-            rdistance(self.image, num_clusters='default', ux='default', uy='incorrect')            
+            rdistance(self.image, num_clusters=20, ux='default', uy='incorrect')            
         with self.assertRaises(ValueError):
-            rdistance(self.image, num_clusters='default', ux=[1,2,3], uy=[1,2])
+            rdistance(self.image, num_clusters=20, ux=[1,2,3], uy=[1,2])
         with self.assertRaises(ValueError):
-            rdistance(self.image, num_clusters='default', ux=[1,2], uy=[1,2,3])
+            rdistance(self.image, num_clusters=20, ux=[1,2], uy=[1,2,3])
 
         ux, uy = [237, 283], [32, 78]
 
-        d = rdistance(self.image, num_clusters='default', ux=ux, uy=uy, verbose=False)
+        d = rdistance(self.image, num_clusters=20, ux=ux, uy=uy, verbose=False)
 
         self.assertTrue(d.shape, self.image.shape)
         self.assertTrue(d.min() >= 0.)


### PR DESCRIPTION
* Changed default value of num_clusters to be explicitly 20 to coincide with distortion analysis from https://doi.org/10.1088/1361-6528/aaf353 (as opposed to using string argument 'default' and assigning a value of 20 inside the function, redundant!)
* Other changes are in support of above, including documentation/example changes and unit test modifications