### PR TITLE
FIX: Resolved characteristic wavelength overestimation via re-scaling

### DIFF
--- a/examples/example_1/config
+++ b/examples/example_1/config
@@ -5,5 +5,5 @@ method = response_distance
 [response_distance]
 shapelet_order = default
 num_clusters = default
-ux = [50, 80]
-uy = [150, 180]
+ux = [109, 158]
+uy = [283, 322]

--- a/examples/example_1/config
+++ b/examples/example_1/config
@@ -4,6 +4,6 @@ method = response_distance
 
 [response_distance]
 shapelet_order = default
-num_clusters = default
+num_clusters = 20
 ux = [109, 158]
 uy = [283, 322]

--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -28,7 +28,7 @@ from shapelets.self_assembly import (
 ## Section 2: parameters
 image_name = "lamSIM1.png"
 shapelet_order = 'default' # can also be integer value to set upper bound
-num_clusters = 'default' # default is 20, can be any other positive integer 
+num_clusters = 20 # default is 20, can be any other positive integer 
 ux = [109, 158]
 uy = [283, 322]
 

--- a/examples/example_1/example_1.py
+++ b/examples/example_1/example_1.py
@@ -29,8 +29,8 @@ from shapelets.self_assembly import (
 image_name = "lamSIM1.png"
 shapelet_order = 'default' # can also be integer value to set upper bound
 num_clusters = 'default' # default is 20, can be any other positive integer 
-ux = [50, 80]
-uy = [150, 180]
+ux = [109, 158]
+uy = [283, 322]
 
 ## Section 3: code
 

--- a/examples/example_3/example_3.py
+++ b/examples/example_3/example_3.py
@@ -33,7 +33,7 @@ pattern_order = "square"
 
 # 3.1: image and output directory handling
 image_path = os.path.join(Path(__file__).parents[0], 'images')
-image = read_image(image_name = image_name, image_path = image_path)
+image = read_image(image_name = image_name, image_path = image_path, do_rescale=False)
 save_path = os.path.join(Path(__file__).parents[0], 'output')
 if not os.path.exists(save_path): 
     os.mkdir(save_path)

--- a/shapelets/self_assembly/wavelength.py
+++ b/shapelets/self_assembly/wavelength.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 
-def get_wavelength(image: np.ndarray, rng: list = [0, 70], verbose: bool = True) -> float:
+def get_wavelength(image: np.ndarray, rng: list = [0, 100], verbose: bool = True) -> float:
     r""" 
     Find characteristic wavelength of an image. Computed using method described in ref. [1].
     

--- a/shapelets/tests/test_self_assembly_basic.py
+++ b/shapelets/tests/test_self_assembly_basic.py
@@ -49,7 +49,7 @@ class TestSelfAssemblyBasic(unittest.TestCase):
         self.assertTrue(isinstance(self.lamSIM, np.ndarray))
         self.assertEqual(self.lamSIM.min(), -1)
         self.assertEqual(self.lamSIM.max(), 1)
-        self.assertEqual(self.lamSIM.shape, (296, 296))
+        self.assertEqual(self.lamSIM.shape, (511, 511))
 
         self.assertTrue(isinstance(self.hexSIM, np.ndarray))
         self.assertEqual(self.hexSIM.min(), -1)
@@ -63,19 +63,19 @@ class TestSelfAssemblyBasic(unittest.TestCase):
 
         lamSIM_wvl = get_wavelength(image = self.lamSIM, verbose = False)
         self.assertTrue(isinstance(lamSIM_wvl, numbers.Real))
-        self.assertAlmostEqual(lamSIM_wvl, 10.231, places = 3)
+        self.assertAlmostEqual(lamSIM_wvl, 17.60, places = 2)
 
         lamSIM_beta_n0 = lambda_to_beta_n0(3, lamSIM_wvl)
         self.assertTrue(isinstance(lamSIM_beta_n0, numbers.Real))
-        self.assertAlmostEqual(lamSIM_beta_n0, 3.41, places = 2)
+        self.assertAlmostEqual(lamSIM_beta_n0, 5.87, places = 2)
 
         lamSIM_beta_n1 = lambda_to_beta_n1(3, lamSIM_wvl)
         self.assertTrue(isinstance(lamSIM_beta_n1, numbers.Real))
-        self.assertAlmostEqual(lamSIM_beta_n1, 7.3, places = 5)
+        self.assertAlmostEqual(lamSIM_beta_n1, 12.4, places = 1)
 
         hexSIM_wvl = get_wavelength(image = self.hexSIM, verbose = False)
         self.assertTrue(isinstance(hexSIM_wvl, numbers.Real))
-        self.assertAlmostEqual(hexSIM_wvl, 16.882, places = 3)
+        self.assertAlmostEqual(hexSIM_wvl, 16.88, places = 2)
         
         hexSIM_beta_n0 = lambda_to_beta_n0(6, hexSIM_wvl)
         self.assertTrue(isinstance(hexSIM_beta_n0, numbers.Real))
@@ -83,7 +83,7 @@ class TestSelfAssemblyBasic(unittest.TestCase):
 
         hexSIM_beta_n1 = lambda_to_beta_n1(6, hexSIM_wvl)
         self.assertTrue(isinstance(hexSIM_beta_n1, numbers.Real))
-        self.assertAlmostEqual(hexSIM_beta_n1, 9.1, places = 5)
+        self.assertAlmostEqual(hexSIM_beta_n1, 9.1, places = 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/shapelets/tests/test_self_assembly_methods.py
+++ b/shapelets/tests/test_self_assembly_methods.py
@@ -41,9 +41,10 @@ class TestSelfAssemblyMethods(unittest.TestCase):
         cls.dir = __file__.replace(os.path.basename(__file__), 'images/')
 
         # Ensure core functions have appropriate outputs before proceeding.
-        # Note that read_image and get_wavelength are not tested here, so inline asserts
-        #   are used to ensure correct output.
+        # NOTE: read_image & get_wavelength are not tested here, so inline asserts are used to ensure correct output.
+        
         cls.image = read_image(image_name="hexSIM1.png", image_path=cls.dir, verbose=False)
+
         assert isinstance(cls.image, np.ndarray)
 
         cls.omega, cls.phi = convresponse_n0(cls.image, shapelet_order='default', verbose=False)


### PR DESCRIPTION
* Fixed issue where characteristic wavelength is overestimated due to small image size via modifications to `shapelets/self_assembly/misc/read_image`
* Updated unit tests after correction of overestimation
* Also forced non-rescaling of sample image for orientation method unit test since larger images = longer runtimes