### PR TITLE
FIX: Updated action version for draft-pdf workflow as per deprecation

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -13,7 +13,7 @@ jobs:
           journal: joss
           paper-path: publications/2309_JOSS/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           path: publications/2309_JOSS/paper.pdf


### PR DESCRIPTION
* Using v1 for github upload-artifact action caused workflow failure
* Required update to v4 as described in deprecation notice: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/