### PR TITLE
Introduce CHANGELOG.md for detailed version control history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ All substantial or important changes to `shapelets` will be written in this file
 - LOG: Modifications to CHANGELOG for version control documentation
 - MNT: General modifications, maintenance (including documentation), or enhancements 
 - NEW: Introduction of a new component or feature
+
+## [1.0] -- 03/14/2024
+- commit 6ce31fbd1194cac024f1f65d2fa7c21ed0c67990
+- NEW: Initial complete and functional release following [JOSS manuscript](https://joss.theoj.org/papers/10.21105/joss.06058) acceptance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All substantial or important changes to `shapelets` will be written in this file
 - MNT: General modifications, maintenance (including documentation), or enhancements 
 - NEW: Introduction of a new component or feature
 
+## [1.1] -- 12/04/2024
+- commit cd45ff9174503c44179538af2d83cf2c2444d53a
+- FIX: Fixed issue where unit tests were not available after pip installation ([#45](https://github.com/uw-comphys/shapelets/pull/45))
+- MNT: Simplified input parameters and improved readability for `shapelets.self_assembly` methods 
+- MNT: Edits to documentation, including examples, README, and official website
+- NEW: Formal library citation now available via CITATION.cff
+- MNT: Minor modifications and corrections to [JOSS manuscript](https://joss.theoj.org/papers/10.21105/joss.06058)
+
 ## [1.0] -- 03/14/2024
 - commit 6ce31fbd1194cac024f1f65d2fa7c21ed0c67990
 - NEW: Initial complete and functional release following [JOSS manuscript](https://joss.theoj.org/papers/10.21105/joss.06058) acceptance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All substantial or important changes to `shapelets` will be written in this file
 - MNT: General modifications, maintenance (including documentation), or enhancements 
 - NEW: Introduction of a new component or feature
 
+## UNRELEASED
+- NEW: Introduced CHANGELOG.md for detailed version control history 
+- NEW: Introduced `shapelets.core` for essential components (i.e., shapelet functions, entry points)
+- FIX: Corrected characteristic wavelength overestimation ([#64](https://github.com/uw-comphys/shapelets/pull/64))
+- FIX: Corrected optimal filter orientation for steerable shapelets ([#62](https://github.com/uw-comphys/shapelets/pull/62)) 
+- MNT: Several documentation changes, including fixes for pdoc website compilation errors 
+- NEW: Added orthonormal (n=1) polar shapelets, with supporting methods and unit tests 
+- FIX: Fixed entry point bug using incorrect python interpreter from local machine ([#55](https://github.com/uw-comphys/shapelets/pull/55))
+- MNT: Merged setup.cfg and MANIFEST.in into pyproject.toml, which now holds all project specifications
+- MNT: Replaced existing Python response distance with C++ implementation, achieving ~15x speed-up!
+
 ## [1.1] -- 12/04/2024
 - commit cd45ff9174503c44179538af2d83cf2c2444d53a
 - FIX: Fixed issue where unit tests were not available after pip installation ([#45](https://github.com/uw-comphys/shapelets/pull/45))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All substantial or important changes to `shapelets` will be written in this file, with each release containing its changes in reverse chronological order.
+
+## Commit Message Index
+- FIX: Fix for current bug(s), with reference to [GitHub issues](https://github.com/uw-comphys/shapelets/issues) when possible 
+- LOG: Modifications to CHANGELOG for version control documentation
+- MNT: General modifications, maintenance (including documentation), or enhancements 
+- NEW: Introduction of a new component or feature

--- a/shapelets/docs/README.md
+++ b/shapelets/docs/README.md
@@ -1,9 +1,0 @@
-This submodule contains documentation for several examples (see below), installation instructions, custom commands, and library interfacing.
-
-Examples for the **shapelets.self_assembly** submodule:
-* Example 1 - computing the response distance ([R. Suderman (2015)](https://doi.org/10.1103/PhysRevE.91.033307))
-* Example 2 - the defect identification method ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
-* Example 3 - local pattern orientation method ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
-
-Examples for the **shapelets.astronomy** submodule:
-* Example 4 - decomposition and reconstruction of images of galaxies ([A. Refregier (2003)](https://doi.org/10.1046/j.1365-8711.2003.05901.x))

--- a/shapelets/docs/changelog.py
+++ b/shapelets/docs/changelog.py
@@ -17,22 +17,6 @@
 
 r"""
 
-This submodule contains documentation for several examples (see below), installation instructions, custom commands, library interfacing, and a CHANGELOG for detailed commit history.
-
-Examples for the **shapelets.self_assembly** submodule:
-* Example 1 - computing the response distance ([R. Suderman (2015)](https://doi.org/10.1103/PhysRevE.91.033307))
-* Example 2 - the defect identification method ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
-* Example 3 - local pattern orientation method ([M.P. Tino (2024)](http://dx.doi.org/10.1088/1361-6528/ad1df4))
-
-Examples for the **shapelets.astronomy** submodule:
-* Example 4 - decomposition and reconstruction of images of galaxies ([A. Refregier (2003)](https://doi.org/10.1046/j.1365-8711.2003.05901.x))
+.. include:: ../CHANGELOG.md
 
 """
-
-from .example_1 import *
-from .example_2 import *
-from .example_3 import *
-from .example_4 import *
-from .installation_guide import *
-from .library_interface import *
-from .custom_commands import *


### PR DESCRIPTION
These commits add a CHANGELOG.md for detailed version control history, which includes
- version 1.0 (03-14-2024)
- version 1.1 (04-12-2024)
- documentation of unreleased changes
- addition of CHANGELOG to official website docs